### PR TITLE
fix: centralize healthcheck pings and preserve exec status

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,19 @@ Usage:
 healthchecksio-cli <check_id> [<signal>]
 ```
 
+or run a command and report its exit status:
+
+```bash
+healthchecksio-cli exec --check <check_id> -- <command> [args...]
+```
+
 or
 
 ```bash
 docker run --rm ghcr.io/sosheskaz/healthchecksio-cli <check_id> [<signal>]
 ```
 
-`signal` is optional, and may be any signal supported by healthchecks.io.
+`signal` is optional. Supported values are `start`, `success`, `failure`, `fail`, `true`, `false`,
+`log`, or a numeric exit status.
 
-The binary has no dependencies outside of the standard library, so it is quite small. Container is
-distroless, to minimize footprint.
+The container is distroless to minimize runtime footprint.

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -1,14 +1,16 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
-	"io"
-	"net/http"
 	"os"
 	"os/exec"
-	"strconv"
+	"strings"
 
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
+
+	"github.com/sosheskaz/healthchecksio-cli/internal/hc"
 )
 
 func execCommand() *cobra.Command {
@@ -16,63 +18,54 @@ func execCommand() *cobra.Command {
 		Use:   "exec [flags] [command...]",
 		Short: "Execute a command and report its status to healthchecks.io",
 		Run: func(cmd *cobra.Command, args []string) {
-			checkId := cmd.Flag("check").Value.String()
-			if checkId == "" {
+			checkID := cmd.Flag("check").Value.String()
+			if checkID == "" {
 				cmd.Println("Please provide a check id")
 				return
 			}
+			checkUUID, err := uuid.Parse(checkID)
+			if err != nil {
+				panic(fmt.Sprintf("check ID %q is not a valid UUID: %+v", checkID, err))
+			}
 
-			subcommand := exec.Command(args[0], args[1:]...)
+			subcommand := exec.CommandContext(cmd.Context(), args[0], args[1:]...) //nolint:gosec // user-provided command
+			subcommand.Stdin = cmd.InOrStdin()
 			subcommand.Stdout = cmd.OutOrStdout()
 			subcommand.Stderr = cmd.ErrOrStderr()
 
-			mustWrite(cmd.ErrOrStderr(), "starting check "+checkId+"\n")
-			if resp, err := http.Get("https://hc-ping.com/" + checkId + "/start"); err != nil {
-				panic(err)
-			} else {
-				defer func() { _ = resp.Body.Close() }()
-				if resp.StatusCode != 200 {
-					bodyData, _ := io.ReadAll(resp.Body)
-					panic(fmt.Sprintf("received unexpected status code from %s %s: %d\n%s", resp.Request.Method, resp.Request.URL, resp.StatusCode, string(bodyData)))
-				}
+			check, err := hc.NewUUIDCheck(checkUUID)
+			if err != nil {
+				panic(fmt.Sprintf("failed to construct check: %+v", err))
+			}
+
+			mustWrite(cmd.ErrOrStderr(), "starting check "+checkID+"\n")
+			if err := check.Start(cmd.Context()); err != nil {
+				panic(fmt.Sprintf("failed to start check: %+v", err))
 			}
 
 			if err := subcommand.Start(); err != nil {
-				panic(err)
+				panic(fmt.Sprintf("failed to start subcommand %q: %+v", strings.Join(subcommand.Args, " "), err))
 			}
 
 			if err := subcommand.Wait(); err != nil {
-				if _, ok := err.(*exec.ExitError); !ok {
+				exitError := &exec.ExitError{}
+				if !errors.As(err, &exitError) {
 					panic(err)
 				}
 			}
 
-			succeeded := subcommand.ProcessState.Success()
+			exitCode := subcommand.ProcessState.ExitCode()
+			mustWrite(cmd.ErrOrStderr(), fmt.Sprintf("completed with exit code %d\n", exitCode))
 
-			var (
-				resp  *http.Response
-				hcErr error
-			)
+			if err := check.CompleteStatus(cmd.Context(), exitCode); err != nil {
+				panic(fmt.Sprintf("failed to complete check: %+v", err))
+			}
 
-			if succeeded {
-				//nolint:errcheck
-				mustWrite(cmd.ErrOrStderr(), "check succeeded\n")
-				resp, hcErr = http.Get("https://hc-ping.com/" + checkId)
-			} else {
-				//nolint:errcheck
+			if exitCode != 0 {
 				mustWrite(cmd.ErrOrStderr(), "check failed\n")
-				resp, hcErr = http.Get("https://hc-ping.com/" + checkId + "/" + strconv.Itoa(subcommand.ProcessState.ExitCode()))
+				os.Exit(exitCode)
 			}
-
-			if hcErr != nil {
-				panic(hcErr)
-			} else if resp.StatusCode != 200 {
-				bodyData, _ := io.ReadAll(resp.Body)
-				panic(fmt.Sprintf("received unexpected status code from %s %s: %d\n%s", resp.Request.Method, resp.Request.URL, resp.StatusCode, string(bodyData)))
-			}
-			defer func() { _ = resp.Body.Close() }()
-
-			os.Exit(subcommand.ProcessState.ExitCode())
+			mustWrite(cmd.ErrOrStderr(), "check succeeded\n")
 		},
 	}
 

--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -1,0 +1,128 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"reflect"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+const execCommandHelperEnv = "HEALTHCHECKSIO_CLI_EXEC_HELPER"
+
+func TestExecCommandReportsSubcommandExitCode(t *testing.T) {
+	t.Parallel()
+
+	checkID := uuid.MustParse("00000000-0000-4000-8000-000000000007")
+	var (
+		mu           sync.Mutex
+		requestPaths []string
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requestPaths = append(requestPaths, r.URL.Path)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	helper := exec.CommandContext(
+		context.Background(),
+		os.Args[0],
+		"-test.run=TestExecCommandHelper",
+		"--",
+		"exec",
+		server.URL,
+		checkID.String(),
+	)
+	helper.Env = append(os.Environ(), execCommandHelperEnv+"=1")
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	helper.Stdout = &stdout
+	helper.Stderr = &stderr
+
+	err := helper.Run()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("helper error = %T %[1]v, want exec.ExitError; stdout: %s; stderr: %s", err, stdout.String(), stderr.String())
+	}
+	if got, want := exitErr.ExitCode(), 7; got != want {
+		t.Fatalf("helper exit code = %d, want %d; stdout: %s; stderr: %s", got, want, stdout.String(), stderr.String())
+	}
+
+	mu.Lock()
+	gotPaths := append([]string(nil), requestPaths...)
+	mu.Unlock()
+	wantPaths := []string{"/" + checkID.String() + "/start", "/" + checkID.String() + "/7"}
+	if !reflect.DeepEqual(gotPaths, wantPaths) {
+		t.Fatalf("request paths = %v, want %v", gotPaths, wantPaths)
+	}
+}
+
+//nolint:paralleltest // helper subprocess mutates process-wide transport and exits intentionally.
+func TestExecCommandHelper(t *testing.T) {
+	if os.Getenv(execCommandHelperEnv) != "1" {
+		return
+	}
+
+	args := os.Args
+	for len(args) > 0 && args[0] != "--" {
+		args = args[1:]
+	}
+	if len(args) < 2 {
+		t.Fatalf("helper mode missing arguments: %v", os.Args)
+	}
+
+	switch args[1] {
+	case "exec":
+		if len(args) != 4 {
+			t.Fatalf("exec helper got args %v, want exec <server-url> <check-id>", args[1:])
+		}
+		routeHealthchecksTo(t, args[2])
+		runExecCommandHelper(t, args[3])
+	case "exit":
+		if len(args) != 3 {
+			t.Fatalf("exit helper got args %v, want exit <code>", args[1:])
+		}
+		code, err := strconv.Atoi(args[2])
+		if err != nil {
+			t.Fatalf("strconv.Atoi(%q) error = %v", args[2], err)
+		}
+		os.Exit(code)
+	default:
+		t.Fatalf("unknown helper mode %q", args[1])
+	}
+}
+
+func runExecCommandHelper(t *testing.T, checkID string) {
+	t.Helper()
+
+	cmd := execCommand()
+	cmd.SetArgs([]string{
+		"--check",
+		checkID,
+		"--",
+		os.Args[0],
+		"-test.run=TestExecCommandHelper",
+		"--",
+		"exit",
+		"7",
+	})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("exec command error = %v", err)
+	}
+	fmt.Fprintln(os.Stderr, "exec command returned without exiting")
+	os.Exit(0)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,14 +1,29 @@
+// Package cmd is the package that contains the CLI commands.
 package cmd
 
 import (
-	"errors"
+	"context"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
+	"strconv"
 
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
+
+	"github.com/sosheskaz/healthchecksio-cli/internal/hc"
 )
+
+type invalidCLIArgsError struct {
+	Arg     string
+	Problem string
+}
+
+func (e *invalidCLIArgsError) Error() string {
+	return fmt.Sprintf("invalid argument: %s (%s)", e.Arg, e.Problem)
+}
+
+var topCommands = make([]func() *cobra.Command, 0)
 
 func rootCmdUsage() string {
 	return fmt.Sprintf(`Usage: %s <check_id> [<signal>]
@@ -17,13 +32,46 @@ func rootCmdUsage() string {
 `, os.Args[0])
 }
 
-var (
-	topCommands = make([]func() *cobra.Command, 0)
-)
-
 func mustWrite(w io.Writer, msg string) {
 	if _, err := w.Write([]byte(msg)); err != nil {
 		panic(err)
+	}
+}
+
+func callbackForSignal(cmd *cobra.Command, check *hc.Check, signal string) (func(context.Context) error, error) {
+	switch signal {
+	case "":
+		return func(ctx context.Context) error {
+			return check.Success(ctx)
+		}, nil
+	case "failure", "fail", "false":
+		return func(ctx context.Context) error {
+			return check.Failure(ctx)
+		}, nil
+	case "success", "true":
+		return func(ctx context.Context) error {
+			return check.Success(ctx)
+		}, nil
+	case "log":
+		return func(ctx context.Context) error {
+			message, err := io.ReadAll(cmd.InOrStdin())
+			if err != nil {
+				return fmt.Errorf("failed to read log message: %w", err)
+			}
+			return check.Log(ctx, string(message))
+		}, nil
+	case "start":
+		return func(ctx context.Context) error {
+			return check.Start(ctx)
+		}, nil
+	default:
+		statusCode, err := strconv.Atoi(signal)
+		if err != nil {
+			return nil, &invalidCLIArgsError{Arg: "signal", Problem: fmt.Sprintf("illegal value %q", signal)}
+		}
+		return func(ctx context.Context) error {
+			return check.CompleteStatus(ctx, statusCode)
+		}, nil
 	}
 }
 
@@ -33,42 +81,46 @@ func rootCommand() *cobra.Command {
 		Short: "Call healthchecks.io checks from the command line",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var (
-				checkId string
+				checkID string
 				signal  string
 			)
 
 			if len(args) == 0 {
 				mustWrite(cmd.ErrOrStderr(), rootCmdUsage())
-				return errors.New("please provide a check id")
+				return &invalidCLIArgsError{"posargs", "check_id not provided"}
 			}
 			if len(args) > 2 {
 				mustWrite(cmd.ErrOrStderr(), rootCmdUsage())
-				return fmt.Errorf("extraneous arguments found: %v", args[2:])
+				return &invalidCLIArgsError{"posargs", "too many arguments"}
 			}
-			checkId = args[0]
+			checkID = args[0]
 			if len(args) > 1 {
 				signal = args[1]
 			}
+			checkUUID, err := uuid.Parse(checkID)
+			if err != nil {
+				return fmt.Errorf("invalid check_id: %w", err)
+			}
 
-			mustWrite(cmd.ErrOrStderr(), "calling check "+checkId)
+			check, err := hc.NewUUIDCheck(checkUUID)
+			if err != nil {
+				return fmt.Errorf("failed to create check: %w", err)
+			}
+
+			callback, err := callbackForSignal(cmd, check, signal)
+			if err != nil {
+				return err
+			}
+
+			if err := callback(cmd.Context()); err != nil {
+				return err
+			}
+
+			mustWrite(cmd.ErrOrStderr(), "calling check "+checkID)
 			if signal != "" {
 				mustWrite(cmd.ErrOrStderr(), " with signal "+signal)
 			}
 			mustWrite(cmd.ErrOrStderr(), "\n")
-
-			url := "https://hc-ping.com/" + checkId
-			if signal != "" {
-				url += "/" + signal
-			}
-
-			resp, err := http.Get(url)
-			if err != nil {
-				return err
-			}
-			defer func() { _ = resp.Body.Close() }()
-			if resp.StatusCode != 200 {
-				return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
-			}
 
 			return nil
 		},
@@ -84,10 +136,12 @@ func rootCommand() *cobra.Command {
 	return c
 }
 
+// Command returns the root command for the healthchecksio-cli application.
 func Command() *cobra.Command {
 	return rootCommand()
 }
 
+// Execute runs the root command.
 func Execute() {
 	err := Command().Execute()
 	if err != nil {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+type rewriteTransport struct {
+	target *url.URL
+	base   http.RoundTripper
+}
+
+func (t rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	rewritten := req.Clone(req.Context())
+	rewritten.URL.Scheme = t.target.Scheme
+	rewritten.URL.Host = t.target.Host
+	rewritten.Host = t.target.Host
+	resp, err := t.base.RoundTrip(rewritten)
+	if err != nil {
+		return nil, fmt.Errorf("round trip rewritten healthchecks request: %w", err)
+	}
+	return resp, nil
+}
+
+func routeHealthchecksTo(t *testing.T, targetURL string) {
+	t.Helper()
+
+	parsed, err := url.Parse(targetURL)
+	if err != nil {
+		t.Fatalf("url.Parse(%q) error = %v", targetURL, err)
+	}
+
+	previousTransport := http.DefaultTransport
+	http.DefaultTransport = rewriteTransport{
+		target: parsed,
+		base:   previousTransport,
+	}
+	t.Cleanup(func() {
+		http.DefaultTransport = previousTransport
+	})
+}
+
+//nolint:paralleltest // mutates process-wide http.DefaultTransport for command HTTP routing.
+func TestRootCommandAcceptsStartSignal(t *testing.T) {
+	checkID := uuid.MustParse("00000000-0000-4000-8000-000000000006")
+	requestPath := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPath <- r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+	routeHealthchecksTo(t, server.URL)
+
+	cmd := rootCommand()
+	cmd.SetArgs([]string{checkID.String(), "start"})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if got, want := <-requestPath, "/"+checkID.String()+"/start"; got != want {
+		t.Fatalf("request path = %q, want %q", got, want)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/sosheskaz/healthchecksio-cli
 
 go 1.25.4
 
-require github.com/spf13/cobra v1.10.2
+require (
+	github.com/google/uuid v1.6.0
+	github.com/spf13/cobra v1.10.2
+)
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/internal/hc/errs.go
+++ b/internal/hc/errs.go
@@ -1,0 +1,55 @@
+package hc
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func reqHeader(req *http.Request) string {
+	if req == nil {
+		return "<nil request>"
+	}
+
+	requestURI := req.RequestURI
+	if requestURI == "" && req.URL != nil {
+		requestURI = req.URL.RequestURI()
+	}
+
+	return req.Method + " " + requestURI
+}
+
+// BadStatusError is returned when a request returns a bad status code.
+type BadStatusError struct {
+	Req        *http.Request
+	StatusCode int
+}
+
+func (e BadStatusError) Error() string {
+	reqSubject := reqHeader(e.Req)
+	return fmt.Sprintf("bad status code for %q: %d", reqSubject, e.StatusCode)
+}
+
+// RequestFailedError is returned when a request fails to complete.
+type RequestFailedError struct {
+	Req *http.Request
+	Err error
+}
+
+func (e RequestFailedError) Error() string {
+	reqSubject := reqHeader(e.Req)
+	return fmt.Sprintf("request failed for %q: %+v", reqSubject, e.Err)
+}
+
+// Unwrap returns the underlying request error.
+func (e RequestFailedError) Unwrap() error {
+	return e.Err
+}
+
+// BadConfigError is returned when the configuration is invalid.
+type BadConfigError struct {
+	Message string
+}
+
+func (e BadConfigError) Error() string {
+	return e.Message
+}

--- a/internal/hc/healthcheck.go
+++ b/internal/hc/healthcheck.go
@@ -1,0 +1,139 @@
+// Package hc provides health check functionality for Healthchecks.io.
+package hc
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+
+	"github.com/google/uuid"
+)
+
+const (
+	// DefaultBaseURL is the default base URL for the healthchecks.io API.
+	DefaultBaseURL = "https://hc-ping.com"
+)
+
+type checkOptions struct {
+	baseURL string
+}
+
+// CheckOption is a function that modifies the check options.
+type CheckOption func(*checkOptions)
+
+// WithBaseURL sets the base URL for the healthchecks.io API.
+func WithBaseURL(baseURL string) CheckOption {
+	return func(c *checkOptions) {
+		c.baseURL = baseURL
+	}
+}
+
+// Check represents a health check on a service.
+type Check struct {
+	checkURL string
+}
+
+// NewUUIDCheck creates a new health check for the given UUID.
+func NewUUIDCheck(id uuid.UUID, opts ...CheckOption) (*Check, error) {
+	if id == uuid.Nil {
+		return nil, BadConfigError{Message: "id must not be nil"}
+	}
+	options := &checkOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	baseURL := DefaultBaseURL
+	if options.baseURL != "" {
+		baseURL = options.baseURL
+	}
+
+	checkURL, err := url.JoinPath(baseURL, id.String())
+	if err != nil {
+		return nil, BadConfigError{Message: fmt.Sprintf("failed to construct URL from %q and %q: %+v", baseURL, id.String(), err)}
+	}
+
+	return &Check{
+		checkURL: checkURL,
+	}, nil
+}
+
+// NewSlugCheck creates a new health check for the given ping key and slug.
+func NewSlugCheck(pingKey, slug string, opts ...CheckOption) (*Check, error) {
+	if pingKey == "" {
+		return nil, BadConfigError{Message: "pingKey must not be empty"}
+	}
+	if slug == "" {
+		return nil, BadConfigError{Message: "slug must not be empty"}
+	}
+
+	options := &checkOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	baseURL := DefaultBaseURL
+	if options.baseURL != "" {
+		baseURL = options.baseURL
+	}
+
+	checkURL, err := url.JoinPath(baseURL, pingKey, slug)
+	if err != nil {
+		return nil, BadConfigError{Message: fmt.Sprintf("failed to construct URL from %q, pingKey (len %d) and %q: %+v", baseURL, len(pingKey), slug, err)}
+	}
+
+	return &Check{
+		checkURL: checkURL,
+	}, nil
+}
+
+// Success sends a success ping to the healthchecks.io API.
+func (c *Check) Success(ctx context.Context, opts ...RequestOption) error {
+	successURL := c.checkURL
+	return simpleHandleURL(ctx, successURL, opts...)
+}
+
+// Start sends a start ping to the healthchecks.io API.
+func (c *Check) Start(ctx context.Context, opts ...RequestOption) error {
+	startURL, err := url.JoinPath(c.checkURL, "start")
+	if err != nil {
+		return BadConfigError{Message: fmt.Sprintf("failed to construct URL from %q and %q: %+v", c.checkURL, "start", err)}
+	}
+	return simpleHandleURL(ctx, startURL, opts...)
+}
+
+// Failure sends a failure ping to the healthchecks.io API.
+func (c *Check) Failure(ctx context.Context, opts ...RequestOption) error {
+	failureURL, err := url.JoinPath(c.checkURL, "fail")
+	if err != nil {
+		return BadConfigError{Message: fmt.Sprintf("failed to construct URL from %q and %q: %+v", c.checkURL, "fail", err)}
+	}
+
+	return simpleHandleURL(ctx, failureURL, opts...)
+}
+
+// Log sends a log message to the healthchecks.io API.
+func (c *Check) Log(ctx context.Context, message string, opts ...RequestOption) error {
+	logURL, err := url.JoinPath(c.checkURL, "log")
+	if err != nil {
+		return BadConfigError{Message: fmt.Sprintf("failed to construct URL from %q and %q: %+v", c.checkURL, "log", err)}
+	}
+
+	opts = append(opts, RequestOption(func(o *requestOptions) {
+		o.diagnostics = message
+	}))
+
+	return simpleHandleURL(ctx, logURL, opts...)
+}
+
+// CompleteStatus sends a status ping to the healthchecks.io API with the given exit code.
+func (c *Check) CompleteStatus(ctx context.Context, status int, opts ...RequestOption) error {
+	statusPath := strconv.Itoa(status)
+	completeURL, err := url.JoinPath(c.checkURL, statusPath)
+	if err != nil {
+		return BadConfigError{Message: fmt.Sprintf("failed to construct URL from %q and %q: %+v", c.checkURL, statusPath, err)}
+	}
+
+	return simpleHandleURL(ctx, completeURL, opts...)
+}

--- a/internal/hc/request.go
+++ b/internal/hc/request.go
@@ -1,0 +1,82 @@
+package hc
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+type requestOptions struct {
+	runID       string
+	diagnostics string
+}
+
+// WithRunID sets the run ID for the request.
+func WithRunID(runID uuid.UUID) RequestOption {
+	return func(opts *requestOptions) {
+		opts.runID = runID.String()
+	}
+}
+
+// WithDiagnostics sets the diagnostics string for the request.
+func WithDiagnostics(diagnostics string) RequestOption {
+	return func(opts *requestOptions) {
+		opts.diagnostics = diagnostics
+	}
+}
+
+// RequestOption is a function that modifies the request behavior of an individual check call.
+type RequestOption func(*requestOptions)
+
+func addRunID(urlStr, runID string) (string, error) {
+	parsedURL, err := url.Parse(urlStr)
+	if err != nil {
+		return "", fmt.Errorf("parse URL: %w", err)
+	}
+
+	query := parsedURL.Query()
+	query.Set("rid", runID)
+	parsedURL.RawQuery = query.Encode()
+
+	return parsedURL.String(), nil
+}
+
+func simpleHandleURL(ctx context.Context, urlStr string, opts ...RequestOption) error {
+	options := new(requestOptions)
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	if options.runID != "" {
+		var err error
+		urlStr, err = addRunID(urlStr, options.runID)
+		if err != nil {
+			return BadConfigError{Message: fmt.Sprintf("failed to construct valid HTTP Request URL from %q: %+v", urlStr, err)}
+		}
+	}
+	var body io.Reader = http.NoBody
+	if options.diagnostics != "" {
+		body = strings.NewReader(options.diagnostics)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, urlStr, body)
+	if err != nil {
+		return BadConfigError{Message: fmt.Sprintf("failed to construct valid HTTP Request to %q: %+v", urlStr, err)}
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return RequestFailedError{Req: req, Err: err}
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return BadStatusError{Req: req, StatusCode: resp.StatusCode}
+	}
+
+	return nil
+}

--- a/internal/hc/request_test.go
+++ b/internal/hc/request_test.go
@@ -1,0 +1,169 @@
+package hc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestCheckReportsBadHTTPStatus(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+
+	checkID := uuid.MustParse("00000000-0000-4000-8000-000000000001")
+	check, err := NewUUIDCheck(checkID, WithBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("NewUUIDCheck() error = %v", err)
+	}
+
+	err = check.Success(context.Background())
+	var statusErr BadStatusError
+	if !errors.As(err, &statusErr) {
+		t.Fatalf("Success() error = %T %[1]v, want BadStatusError", err)
+	}
+	if statusErr.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("BadStatusError.StatusCode = %d, want %d", statusErr.StatusCode, http.StatusInternalServerError)
+	}
+	if got, want := statusErr.Req.URL.Path, "/"+checkID.String(); got != want {
+		t.Fatalf("BadStatusError.Req.URL.Path = %q, want %q", got, want)
+	}
+}
+
+func TestCheckReportsRequestFailureCause(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	serverURL := server.URL
+	server.Close()
+
+	checkID := uuid.MustParse("00000000-0000-4000-8000-000000000002")
+	check, err := NewUUIDCheck(checkID, WithBaseURL(serverURL))
+	if err != nil {
+		t.Fatalf("NewUUIDCheck() error = %v", err)
+	}
+
+	err = check.Success(context.Background())
+	var requestErr RequestFailedError
+	if !errors.As(err, &requestErr) {
+		t.Fatalf("Success() error = %T %[1]v, want RequestFailedError", err)
+	}
+	if requestErr.Err == nil {
+		t.Fatal("RequestFailedError.Err = nil, want underlying request error")
+	}
+}
+
+func TestCheckAddsRunIDToExistingQuery(t *testing.T) {
+	t.Parallel()
+
+	requestQuery := make(chan url.Values, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestQuery <- r.URL.Query()
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	checkID := uuid.MustParse("00000000-0000-4000-8000-000000000003")
+	runID := uuid.MustParse("00000000-0000-4000-8000-000000000004")
+	check, err := NewUUIDCheck(checkID, WithBaseURL(server.URL+"?existing=true"))
+	if err != nil {
+		t.Fatalf("NewUUIDCheck() error = %v", err)
+	}
+
+	if err := check.Success(context.Background(), WithRunID(runID)); err != nil {
+		t.Fatalf("Success() error = %v", err)
+	}
+
+	got := <-requestQuery
+	if got.Get("existing") != "true" {
+		t.Fatalf("query existing = %q, want true", got.Get("existing"))
+	}
+	if got.Get("rid") != runID.String() {
+		t.Fatalf("query rid = %q, want %q", got.Get("rid"), runID.String())
+	}
+}
+
+func TestCheckMethodsUseExpectedPathsAndBodies(t *testing.T) {
+	t.Parallel()
+
+	type requestRecord struct {
+		path string
+		body string
+	}
+
+	records := make(chan requestRecord, 5)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() { _ = r.Body.Close() }()
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("io.ReadAll() error = %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		records <- requestRecord{path: r.URL.Path, body: string(body)}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	checkID := uuid.MustParse("00000000-0000-4000-8000-000000000005")
+	check, err := NewUUIDCheck(checkID, WithBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("NewUUIDCheck() error = %v", err)
+	}
+
+	ctx := context.Background()
+	calls := []struct {
+		name string
+		call func() error
+		path string
+		body string
+	}{
+		{name: "success", call: func() error { return check.Success(ctx) }, path: "/" + checkID.String()},
+		{name: "start", call: func() error { return check.Start(ctx) }, path: "/" + checkID.String() + "/start"},
+		{name: "failure", call: func() error { return check.Failure(ctx) }, path: "/" + checkID.String() + "/fail"},
+		{name: "complete status", call: func() error { return check.CompleteStatus(ctx, 7) }, path: "/" + checkID.String() + "/7"},
+		{name: "log", call: func() error { return check.Log(ctx, "diagnostics") }, path: "/" + checkID.String() + "/log", body: "diagnostics"},
+	}
+
+	for _, tc := range calls {
+		if err := tc.call(); err != nil {
+			t.Fatalf("%s call error = %v", tc.name, err)
+		}
+		record := <-records
+		if record.path != tc.path {
+			t.Fatalf("%s path = %q, want %q", tc.name, record.path, tc.path)
+		}
+		if record.body != tc.body {
+			t.Fatalf("%s body = %q, want %q", tc.name, record.body, tc.body)
+		}
+	}
+}
+
+func TestBadStatusErrorMessageIncludesRequestPath(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequestWithContext(
+		context.Background(),
+		http.MethodPost,
+		"https://example.com/check/start?rid=abc",
+		http.NoBody,
+	)
+	req.RequestURI = ""
+	err := BadStatusError{Req: req, StatusCode: http.StatusNotFound}
+
+	got := err.Error()
+	want := fmt.Sprintf("bad status code for %q: %d", "POST /check/start?rid=abc", http.StatusNotFound)
+	if got != want {
+		t.Fatalf("Error() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Moves Healthchecks.io request handling into an internal client package and fixes CLI behavior around signal handling, request errors, and `exec` exit reporting.

## Changes

- Added `internal/hc` for check construction, ping URL construction, request execution, diagnostics payloads, and run ID support.
- Added typed errors for bad config, failed requests, and non-200 Healthchecks responses.
- Updated the root command to use the internal Healthchecks client instead of direct `http.Get` calls.
- Added explicit root command handling for `start`, `success`, `failure`, `fail`, `true`, `false`, `log`, and numeric exit status signals.
- Updated `exec` to use context-aware subprocess execution.
- Forwarded stdin to the executed subprocess.
- Fixed `exec` so non-zero subprocess exits are treated as expected command results, not panics.
- Fixed `exec` to send the final exit status ping before exiting with the subprocess status code.
- Added regression tests for root `start`, `exec` non-zero status reporting, ping paths, diagnostics bodies, run ID query handling, bad status errors, and request failure causes.
- Updated README usage for `exec`, supported signals, and runtime footprint wording.
- Added the UUID dependency required by the new check ID parsing path.

## Notes

The root and exec commands now validate check IDs as UUIDs. That matches the new client path, but it is worth confirming arbitrary Healthchecks ping paths are not a supported compatibility requirement.