### PR TITLE
ci: add mise-backed lint and release validation

### DIFF
--- a/.github/problem-matchers/golangci-lint.json
+++ b/.github/problem-matchers/golangci-lint.json
@@ -1,0 +1,17 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "golangci-lint",
+      "severity": "warning",
+      "pattern": [
+        {
+          "regexp": "^([^\\s].*):(\\d+):(\\d+):\\s+(.+)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,55 +3,57 @@ name: CI
 on:
   pull_request:
   push:
+    branches:
+      - main
 
 env:
   CGO_ENABLED: '0'
 
 jobs:
-  go-setup:
+  go:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          go-version-file: go.mod
-      - run: go mod download
-      - run: go build ./...
+          install_args: 'go golangci-lint'
+      - name: Setup Golang caches
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+            ~/.cache/golangci-lint
+          key: ${{ runner.os }}-golang-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-golang-
 
-  golangci-lint:
-    needs: go-setup
+      - name: Mod download
+        run: go mod download
+
+      - name: Build
+        run: go build ./...
+
+      - name: Mod tidy
+        run: go mod tidy -diff -v
+
+      - name: Test
+        run: go test -v ./...
+
+      - name: Lint
+        run: |
+          echo "::add-matcher::.github/problem-matchers/golangci-lint.json"
+          golangci-lint run --output.text.path=stdout --output.text.print-issued-lines=false --output.text.colors=false
+          echo "::remove-matcher owner=golangci-lint::"
+
+  goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          go-version-file: go.mod
-      - uses: golangci/golangci-lint-action@v9
-  go-test:
-    needs: go-setup
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-      - run: go mod tidy -diff -v
-      - run: go vet ./...
-      - run: go test -v ./...
-      - run: test -z "$(gofmt -l .)"
-  go-releaser-check:
-    needs: go-setup
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-      - uses: goreleaser/goreleaser-action@v6
-        with:
-          version: '~> v2'
-          args: check
-      - uses: goreleaser/goreleaser-action@v6
-        with:
-          version: '~> v2'
-          args: release --snapshot --clean
+          install_args: 'go goreleaser'
+      - name: Check goreleaser
+        run: |
+          goreleaser check
+          goreleaser release --snapshot --clean

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,8 @@ permissions:
   packages: write
 
 env:
-  REF: ${{ github.event.inputs.tag || github.ref }}
-  TAP_GITHUB_TOKEN: ${{ github.event.inputs.tap_github_token || secrets.BREW_PAT || github.token }}
+  REF: ${{ inputs.release_tag || github.ref }}
+  TAP_GITHUB_TOKEN: ${{ inputs.tap_github_token || secrets.BREW_PAT || github.token }}
 
 jobs:
   goreleaser:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -50,6 +50,7 @@ linters:
     - sqlclosecheck   # Check that sql.Rows and sql.Stmt are closed
     - testifylint     # Check usage of github.com/stretchr/testify
     - tparallel       # Detects inappropriate usage of t.Parallel() method in Go tests
+    - usetesting      # Reports uses of functions with replacement inside the testing package
     - unconvert       # Remove unnecessary type conversions
     - unparam         # Report unused function parameters
     - usestdlibvars   # Detect the possibility to use variables/constants from the Go standard library
@@ -223,6 +224,10 @@ linters:
           pkg: fmt
           msg: use log/slog or logr instead of fmt.Print*
       analyze-types: true
+
+    usetesting:
+      context-background: true
+      context-todo: true
 
     whitespace:
       multi-if: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,328 @@
+# golangci-lint configuration for healthchecksio-cli
+# golangci-lint v2 configuration format
+version: "2"
+
+run:
+  timeout: 5m
+  tests: true
+  modules-download-mode: readonly
+  allow-parallel-runners: true
+
+output:
+  formats:
+    text:
+      path: stdout
+
+linters:
+  default: none
+  enable:
+    # Bugs and correctness
+    - errcheck        # Check for unchecked errors
+    - govet           # Reports suspicious constructs
+    - ineffassign     # Detect ineffectual assignments
+    - staticcheck     # Go static analysis
+    - unused          # Check for unused code
+    - asasalint       # Check for pass []any as any in variadic func(...any)
+    - asciicheck      # Check for non-ASCII identifiers
+    - bidichk         # Check for dangerous unicode character sequences
+    - bodyclose       # Check whether HTTP response body is closed
+    - contextcheck    # Check whether the function uses a non-inherited context
+    - copyloopvar     # Detect places where loop variables are copied
+    - durationcheck   # Check for two durations multiplied together
+    - errname         # Check that error types are named FooError
+    - errorlint       # Find code that will cause problems with Go 1.13 error wrapping
+    - exhaustive      # Check exhaustiveness of enum switch statements
+    - gocritic        # Opinionated Go source code checker
+    - goprintffuncname # Check that printf-like functions are named with f at the end
+    - gosec           # Inspect source code for security problems
+    - intrange        # Find places where for loops could use an integer range
+    - makezero        # Find slice declarations with non-zero initial length
+    - mirror          # Reports wrong mirror patterns of bytes/strings usage
+    - musttag         # Enforce field tags in (un)marshaled structs
+    - nilerr          # Find code that returns nil even if it checks that the error is not nil
+    - nilnil          # Check that there is no simultaneous return of nil error and invalid value
+    - noctx           # Find sending HTTP requests without context.Context
+    - nosprintfhostport # Check for misuse of Sprintf to construct a host with port in a URL
+    - predeclared     # Find code that shadows one of Go's predeclared identifiers
+    - reassign        # Check that package variables are not reassigned
+    - revive          # Fast, configurable, extensible, flexible, and beautiful linter for Go
+    - rowserrcheck    # Check whether Err of rows is checked
+    - sqlclosecheck   # Check that sql.Rows and sql.Stmt are closed
+    - testifylint     # Check usage of github.com/stretchr/testify
+    - tparallel       # Detects inappropriate usage of t.Parallel() method in Go tests
+    - unconvert       # Remove unnecessary type conversions
+    - unparam         # Report unused function parameters
+    - usestdlibvars   # Detect the possibility to use variables/constants from the Go standard library
+    - wastedassign    # Find wasted assignment statements
+    - whitespace      # Detect leading and trailing whitespace
+
+    # Code quality and style
+    - containedctx    # Detect struct that contains a context.Context field
+    - dogsled         # Check for too many blank identifiers (e.g. x, _, _, _, := f())
+    - dupl            # Code clone detection
+    - dupword         # Check for duplicate words in comments
+    - errchkjson      # Check types passed to the json encoding functions
+    - forcetypeassert # Find forced type assertions
+    - gocognit        # Compute and check the cognitive complexity of functions
+    - goconst         # Find repeated strings that could be replaced by a constant
+    - gocyclo         # Compute and check the cyclomatic complexity of functions
+    - godot           # Check if comments end in a period
+    - err113          # Check the errors handling expressions
+    - gomoddirectives # Manage the use of 'replace', 'retract', and 'excludes' directives in go.mod
+    - grouper         # Analyze expression groups
+    - importas        # Enforce consistent import aliases
+    - inamedparam     # Report interfaces with unnamed method parameters
+    - interfacebloat  # Check the number of methods inside an interface
+    - lll             # Report long lines
+    - maintidx        # Measure the maintainability index of each function
+    - misspell        # Find commonly misspelled English words in comments
+    - nakedret        # Find naked returns in functions greater than a specified function length
+    - nestif          # Report deeply nested if statements
+    - nolintlint      # Report ill-formed or insufficient nolint directives
+    - nonamedreturns  # Report all named returns
+    - paralleltest    # Detect missing usage of t.Parallel() method in Go tests
+    - prealloc        # Find slice declarations that could potentially be pre-allocated
+    - forbidigo       # Forbid use of banned identifiers (e.g. log package)
+    - sloglint        # Ensure consistent code style when using log/slog
+    - tagliatelle     # Check struct tags
+    - thelper         # Detect test helpers without t.Helper() call
+    - wrapcheck       # Check that errors from external packages are wrapped
+
+  settings:
+    errcheck:
+      check-type-assertions: true
+      check-blank: true
+      exclude-functions:
+        - (io.Closer).Close
+        - (*os.File).Close
+
+    govet:
+      enable-all: true
+      settings:
+        shadow:
+          strict: true
+
+    gocyclo:
+      min-complexity: 15
+
+    gocognit:
+      min-complexity: 30
+
+    goconst:
+      min-len: 3
+      min-occurrences: 3
+      ignore-tests: true
+
+    gocritic:
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+      disabled-checks:
+        - whyNoLint
+        - unnamedResult
+
+    gosec:
+      confidence: medium
+      severity: medium
+      excludes:
+        - G104
+
+    lll:
+      line-length: 160
+      tab-width: 1
+
+    misspell:
+      locale: US
+
+    nakedret:
+      max-func-lines: 30
+
+    nestif:
+      min-complexity: 5
+
+    nolintlint:
+      allow-unused: false
+      require-explanation: true
+      require-specific: true
+
+    revive:
+      confidence: 0.8
+      severity: warning
+      rules:
+        - name: blank-imports
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: dot-imports
+        - name: error-return
+        - name: error-strings
+        - name: error-naming
+        - name: exported
+          arguments:
+            - "checkPrivateReceivers"
+            - "sayRepetitiveInsteadOfStutters"
+        - name: if-return
+        - name: increment-decrement
+        - name: var-naming
+        - name: var-declaration
+        - name: package-comments
+        - name: range
+        - name: receiver-naming
+        - name: time-naming
+        - name: unexported-return
+        - name: indent-error-flow
+        - name: errorf
+        - name: empty-block
+        - name: superfluous-else
+        - name: unused-parameter
+        - name: unreachable-code
+        - name: redefines-builtin-id
+        - name: waitgroup-by-value
+        - name: unconditional-recursion
+        - name: struct-tag
+        - name: early-return
+        - name: defer
+          arguments:
+            - ["call-chain", "loop", "method-call", "recover", "return"]
+
+    tagliatelle:
+      case:
+        rules:
+          json: snake
+          yaml: snake
+          xml: camel
+          bson: camel
+          avro: snake
+          mapstructure: kebab
+
+    testifylint:
+      enable-all: true
+
+    wrapcheck:
+      ignore-sigs:
+        - .Errorf(
+        - errors.New(
+        - errors.Unwrap(
+        - errors.Join(
+        - .Wrap(
+        - .Wrapf(
+        - .WithMessage(
+        - .WithMessagef(
+        - .WithStack(
+      ignore-package-globs:
+        - github.com/sosheskaz/healthchecksio-cli/*
+
+    forbidigo:
+      forbid:
+        - pattern: ^log\.
+          pkg: log
+          msg: use log/slog or logr instead of the log package
+        - pattern: ^fmt\.Print
+          pkg: fmt
+          msg: use log/slog or logr instead of fmt.Print*
+      analyze-types: true
+
+    whitespace:
+      multi-if: true
+      multi-func: true
+
+    importas:
+      no-unaliased: true
+      alias:
+        - pkg: k8s.io/api/core/v1
+          alias: corev1
+        - pkg: k8s.io/api/policy/v1
+          alias: policyv1
+        - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+          alias: metav1
+        - pkg: k8s.io/apimachinery/pkg/api/errors
+          alias: apierrors
+
+    interfacebloat:
+      max: 10
+
+    maintidx:
+      under: 20
+
+    paralleltest:
+      ignore-missing: false
+      ignore-missing-subtests: false
+
+  exclusions:
+    rules:
+      # Exclude some linters from running on tests files
+      - path: _test\.go
+        linters:
+          - gocyclo
+          - errcheck
+          - dupl
+          - gosec
+          - goconst
+          - gocognit
+          - maintidx
+
+      # Exclude lll issues for long lines with go:generate
+      - linters:
+          - lll
+        source: "^//go:generate "
+
+      # Exclude shadow check on err variables
+      - linters:
+          - govet
+        text: "declaration of \"err\" shadows declaration"
+
+      # Allow main() and init() to be complex
+      - path: main\.go
+        text: "Function 'main' is too long"
+        linters:
+          - gocyclo
+          - gocognit
+
+    paths:
+      - vendor
+      - third_party
+      - testdata
+      - examples
+      - _tools
+      - ".*\\.pb\\.go$"
+      - ".*\\.gen\\.go$"
+
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+  settings:
+    gofumpt:
+      module-path: github.com/sosheskaz/healthchecksio-cli
+      extra-rules: true
+    goimports:
+      local-prefixes:
+        - github.com/sosheskaz/healthchecksio-cli
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/sosheskaz/healthchecksio-cli)
+      custom-order: true
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+  new: false
+  fix: false
+
+severity:
+  default: warning
+  rules:
+    - linters:
+        - dupl
+      severity: info
+    - linters:
+        - errcheck
+        - govet
+        - staticcheck
+      severity: error

--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -36,7 +35,7 @@ func TestExecCommandReportsSubcommandExitCode(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	helper := exec.CommandContext(
-		context.Background(),
+		t.Context(),
 		os.Args[0],
 		"-test.run=TestExecCommandHelper",
 		"--",

--- a/internal/hc/request_test.go
+++ b/internal/hc/request_test.go
@@ -1,7 +1,6 @@
 package hc
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -27,7 +26,7 @@ func TestCheckReportsBadHTTPStatus(t *testing.T) {
 		t.Fatalf("NewUUIDCheck() error = %v", err)
 	}
 
-	err = check.Success(context.Background())
+	err = check.Success(t.Context())
 	var statusErr BadStatusError
 	if !errors.As(err, &statusErr) {
 		t.Fatalf("Success() error = %T %[1]v, want BadStatusError", err)
@@ -53,7 +52,7 @@ func TestCheckReportsRequestFailureCause(t *testing.T) {
 		t.Fatalf("NewUUIDCheck() error = %v", err)
 	}
 
-	err = check.Success(context.Background())
+	err = check.Success(t.Context())
 	var requestErr RequestFailedError
 	if !errors.As(err, &requestErr) {
 		t.Fatalf("Success() error = %T %[1]v, want RequestFailedError", err)
@@ -80,7 +79,7 @@ func TestCheckAddsRunIDToExistingQuery(t *testing.T) {
 		t.Fatalf("NewUUIDCheck() error = %v", err)
 	}
 
-	if err := check.Success(context.Background(), WithRunID(runID)); err != nil {
+	if err := check.Success(t.Context(), WithRunID(runID)); err != nil {
 		t.Fatalf("Success() error = %v", err)
 	}
 
@@ -121,7 +120,7 @@ func TestCheckMethodsUseExpectedPathsAndBodies(t *testing.T) {
 		t.Fatalf("NewUUIDCheck() error = %v", err)
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	calls := []struct {
 		name string
 		call func() error
@@ -153,7 +152,7 @@ func TestBadStatusErrorMessageIncludesRequestPath(t *testing.T) {
 	t.Parallel()
 
 	req := httptest.NewRequestWithContext(
-		context.Background(),
+		t.Context(),
 		http.MethodPost,
 		"https://example.com/check/start?rid=abc",
 		http.NoBody,

--- a/main.go
+++ b/main.go
@@ -1,5 +1,6 @@
-//go:generate go run gen.go
+// Package main is the entrypoint for the healthchecks.io CLI
 
+//go:generate go run gen.go
 package main
 
 import "github.com/sosheskaz/healthchecksio-cli/cmd"

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,6 @@
+[tools]
+go = "1.25.4"
+golangci-lint = "2.12.2"
+goreleaser = "2.16.0"
+
+"aqua:rhysd/actionlint" = "1.7.12"


### PR DESCRIPTION
Pins validation tooling with mise and consolidates the primary CI workflow around build, test, tidy, lint, and GoReleaser checks.

## Changes

- Added `mise.toml` with pinned versions for Go, golangci-lint, GoReleaser, actionlint.
- Added `.golangci.yml` using the golangci-lint v2 config format.
- Added a GitHub problem matcher for golangci-lint output.
- Updated CI to install Go and golangci-lint through mise.
- Consolidated CI validation into build, module tidy, test, and golangci-lint steps.
- Added GoReleaser config validation and snapshot release checks to CI.
- Updated formatter and import grouping settings for the project module path.
- Fixed release workflow input handling to use `inputs.release_tag` and `inputs.tap_github_token`.
- Added lint-driven package comments and import formatting needed by the stricter lint profile.