### PR TITLE
deps(actions): use semanticCommitTypeAll(deps) for all Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    ":semanticCommitTypeAll(deps)"
   ],
   "semanticCommits": "enabled",
   "semanticCommitType": "deps",


### PR DESCRIPTION
## Summary

- Adds `:semanticCommitTypeAll(deps)` to `extends` in `renovate.json`
- Fixes Go (and other) updates committing as `chore(go)` instead of `deps(go)`

`config:recommended` sets `semanticCommitType: "chore"` for some managers. Appending this preset after it ensures `deps` wins for all update types.