### PR TITLE
feat: add dependencies section to release-please changelog

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,7 +20,7 @@ jobs:
       - id: release-please
         uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         with:
-          release-type: go
+          config-file: release-please-config.json
           token: ${{ secrets.GITHUB_TOKEN }}
     outputs:
       releases_created: ${{ steps.release-please.outputs.releases_created }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "release-type": "go",
+  "changelog-sections": [
+    {"type": "feat", "section": "Features"},
+    {"type": "feature", "section": "Features"},
+    {"type": "fix", "section": "Bug Fixes"},
+    {"type": "perf", "section": "Performance Improvements"},
+    {"type": "revert", "section": "Reverts"},
+    {"type": "deps", "section": "Dependencies"},
+    {"type": "docs", "section": "Documentation", "hidden": true},
+    {"type": "style", "section": "Styles", "hidden": true},
+    {"type": "chore", "section": "Miscellaneous Chores", "hidden": true},
+    {"type": "refactor", "section": "Code Refactoring", "hidden": true},
+    {"type": "test", "section": "Tests", "hidden": true},
+    {"type": "build", "section": "Build System", "hidden": true},
+    {"type": "ci", "section": "Continuous Integration", "hidden": true}
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `release-please-config.json` with `changelog-sections` including a visible **Dependencies** section for `deps` commits
- Switches the workflow from inline `release-type: go` to `config-file: release-please-config.json`
- All default conventional commit sections are preserved; `deps` is inserted between Reverts and the hidden sections

## Notes

No `.release-please-manifest.json` is created — release-please will generate it on first run.