### PR TITLE
ci(renovate): use semver versioning for github-actions dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,7 +25,8 @@
       "matchManagers": ["github-actions"],
       "semanticCommitScope": "actions",
       "semanticCommitType": "ci",
-      "pinDigests": true
+      "pinDigests": true,
+      "versioning": "semver"
     },
     {
       "matchManagers": ["mise"],


### PR DESCRIPTION
## Summary

- Adds `versioning: "semver"` to the `github-actions` Renovate package rule
- Fixes digest-pinned GHA updates annotating with floating tags (e.g. `# v5`) instead of full semver tags (e.g. `# v5.0.0`) when upstreams publish multiple tags to the same commit
- Applies consistently to all GHA deps — all actions in this repo already use semver, so there's no narrower scope needed

Closes #32 indirectly — Renovate will re-open that PR with `# v5.0.0` once this merges.