### PR TITLE
ci(release-please): add packages config to fix missing release PRs

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "go",
+  "packages": {
+    ".": {}
+  },
   "changelog-sections": [
     {"type": "feat", "section": "Features"},
     {"type": "feature", "section": "Features"},


### PR DESCRIPTION
Without a `packages` key in `release-please-config.json`, release-please's `parseConfig` builds an empty `repositoryConfig`. This means no path is registered for the root component, every existing release tag produces a "Found release tag with component '', but not configured in manifest" warning, the baseline SHA set stays empty, and 0 commits are ever collected — so no release PR is opened for `deps` commits (or any commits).