### PR TITLE
fix(release-please): skip GitHub release creation to avoid conflict with goreleaser

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "go",
+  "skip-github-release": true,
   "packages": {
     ".": {}
   },


### PR DESCRIPTION
After #48 fixed the missing `packages` config, release-please now correctly processes merged release PRs — but then tries to create the GitHub release itself, conflicting with goreleaser. The result is a 403 "Resource not accessible by integration" error because goreleaser already owns that responsibility via `push: tags: v*`.

## Why

Both tools were trying to create the same GitHub release. Release-please ran first (as part of the release-please workflow), hit an already-existing release or a token scope issue, and failed. Goreleaser is the right owner of the GitHub release since it builds and attaches binaries.

## Design

`skip-github-release: true` tells release-please to manage the PR, changelog, manifest update, and git tag — but leave the GitHub release object to goreleaser. The tag push still triggers goreleaser via `push: tags: v*`, and `releases_created` is still set correctly for the `workflow_call` path.