### PR TITLE
ci(goreleaser): remove push:tags trigger to prevent double release run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*'
   workflow_dispatch:
     inputs:
       release_tag:


### PR DESCRIPTION
Release-please triggers goreleaser via `workflow_call` after successfully creating a GitHub release. The `push: tags: v*` trigger in `release.yml` fires a second independent goreleaser run for the same tag, which would conflict with the first (goreleaser v2 has no skip-if-exists option for releases).