### PR TITLE
ci(goreleaser): fetch full git history for release checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ env.REF }}
+          fetch-depth: 0
           fetch-tags: true
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:


### PR DESCRIPTION
The goreleaser checkout uses `fetch-tags: true` but defaults to `fetch-depth: 1` (shallow clone). Goreleaser needs the full commit history to walk back to the previous tag for changelog generation and version calculations. Adding `fetch-depth: 0` fetches the complete history.