### PR TITLE
ci(renovate): automerge CI updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,12 +26,19 @@
       "semanticCommitScope": "actions",
       "semanticCommitType": "ci",
       "pinDigests": true,
-      "versioning": "semver"
+      "versioning": "semver",
+      "automerge": true
     },
     {
       "matchManagers": ["mise"],
       "semanticCommitScope": "mise",
       "semanticCommitType": "ci"
+    },
+    {
+      "matchManagers": ["mise"],
+      "matchDepNames": ["!go"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true
     },
     {
       "matchManagers": ["gomod"],


### PR DESCRIPTION
Configures Renovate to automerge CI-owned updates, following the pattern from `thousand-sunny`: GitHub Actions updates automerge, and non-Go `mise` minor/patch tool updates automerge while Go stays on the existing dependency update path.

## Design

The `mise` automerge rule excludes `go` so toolchain and CI helper updates can flow automatically without changing how Go runtime updates are reviewed.