### PR TITLE
feat: report build version at runtime via --version

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,6 +18,13 @@ builds:
       - darwin
     flags:
       - -trimpath
+    # CommitDate/CommitTimestamp (not build time) keep builds reproducible.
+    ldflags:
+      - -s -w
+      - -X github.com/sosheskaz/healthchecksio-cli/internal/version.version={{ .Version }}
+      - -X github.com/sosheskaz/healthchecksio-cli/internal/version.commit={{ .FullCommit }}
+      - -X github.com/sosheskaz/healthchecksio-cli/internal/version.date={{ .CommitDate }}
+    mod_timestamp: '{{ .CommitTimestamp }}'
 
 archives:
   - formats: [tar.gz]

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/sosheskaz/healthchecksio-cli/internal/hc"
+	"github.com/sosheskaz/healthchecksio-cli/internal/version"
 )
 
 type invalidCLIArgsError struct {
@@ -77,8 +78,9 @@ func callbackForSignal(cmd *cobra.Command, check *hc.Check, signal string) (func
 
 func rootCommand() *cobra.Command {
 	c := &cobra.Command{
-		Use:   "healthchecksio-cli <check_id> [<signal>]",
-		Short: "Call healthchecks.io checks from the command line",
+		Use:     "healthchecksio-cli <check_id> [<signal>]",
+		Short:   "Call healthchecks.io checks from the command line",
+		Version: version.Get().String(),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var (
 				checkID string

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,84 @@
+// Package version reports the binary's provenance, preferring values
+// injected by release ldflags and falling back to the VCS metadata the Go
+// toolchain embeds in ad-hoc builds.
+package version
+
+import (
+	"runtime/debug"
+	"strings"
+)
+
+// Injected by goreleaser via -ldflags="-X ...". Empty in ad-hoc builds,
+// where Get falls back to debug.ReadBuildInfo.
+var (
+	version = ""
+	commit  = ""
+	date    = ""
+)
+
+// Info describes how the running binary was built.
+type Info struct {
+	Version  string
+	Commit   string
+	Date     string
+	Modified bool
+}
+
+// Get resolves build provenance. Release builds carry exact values from
+// goreleaser; ad-hoc `go build` binaries report the module version the
+// toolchain derived plus VCS revision, timestamp, and dirty state.
+func Get() Info {
+	info := Info{Version: version, Commit: commit, Date: date}
+	buildInfo, ok := debug.ReadBuildInfo()
+	if !ok {
+		return info
+	}
+	if info.Version == "" {
+		info.Version = buildInfo.Main.Version
+	}
+	for _, setting := range buildInfo.Settings {
+		switch setting.Key {
+		case "vcs.revision":
+			if info.Commit == "" {
+				info.Commit = setting.Value
+			}
+		case "vcs.time":
+			if info.Date == "" {
+				info.Date = setting.Value
+			}
+		case "vcs.modified":
+			info.Modified = setting.Value == "true"
+		}
+	}
+	return info
+}
+
+// String renders the info as a single human-readable line, omitting fields
+// that are unavailable for this build.
+func (i Info) String() string {
+	var b strings.Builder
+	if i.Version != "" {
+		b.WriteString(i.Version)
+	} else {
+		b.WriteString("unknown")
+	}
+
+	var details []string
+	if i.Commit != "" {
+		short := i.Commit
+		if len(short) > 12 {
+			short = short[:12]
+		}
+		details = append(details, "commit "+short)
+	}
+	if i.Date != "" {
+		details = append(details, "built "+i.Date)
+	}
+	if i.Modified {
+		details = append(details, "dirty")
+	}
+	if len(details) > 0 {
+		b.WriteString(" (" + strings.Join(details, ", ") + ")")
+	}
+	return b.String()
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,61 @@
+package version
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestInfoString(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		want string
+		info Info
+	}{
+		{
+			name: "release build",
+			info: Info{Version: "1.2.3", Commit: "0123456789abcdef0123", Date: "2026-07-02T17:00:00Z"},
+			want: "1.2.3 (commit 0123456789ab, built 2026-07-02T17:00:00Z)",
+		},
+		{
+			name: "ad-hoc dirty build",
+			info: Info{Version: "(devel)", Commit: "0123456789abcdef0123", Modified: true},
+			want: "(devel) (commit 0123456789ab, dirty)",
+		},
+		{
+			name: "short commit is not truncated",
+			info: Info{Version: "1.0.0", Commit: "abc1234"},
+			want: "1.0.0 (commit abc1234)",
+		},
+		{
+			name: "version only",
+			info: Info{Version: "1.0.0"},
+			want: "1.0.0",
+		},
+		{
+			name: "nothing known",
+			info: Info{},
+			want: "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.info.String(); got != tt.want {
+				t.Fatalf("String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetReportsAVersion(t *testing.T) {
+	t.Parallel()
+	info := Get()
+	if info.Version == "" {
+		t.Fatal("Get() returned an empty version; expected ldflags value or build-info fallback")
+	}
+	if strings.Contains(info.String(), "  ") {
+		t.Fatalf("String() contains doubled spaces: %q", info.String())
+	}
+}


### PR DESCRIPTION
Adds a `--version` flag that reports the binary's build provenance.

## Changes

- New `internal/version` package: prefers values injected by goreleaser ldflags, falling back to Go's embedded VCS buildinfo (revision, timestamp, dirty flag) for ad-hoc `go build`/`go run` builds.
- Wired to cobra's built-in `--version` flag via `Version: version.Get().String()` on the root command.
- `.goreleaser.yaml`: sets the new ldflags (plus `-s -w` to strip release binaries) and `mod_timestamp` from the commit timestamp so builds stay reproducible.

## Design

Ported from `sosheskaz-systems/npc#9`'s `internal/version` package — same fallback logic, adapted to this module's path.

## Caveats

Stacked on top of a following CI-overhaul PR (not the other way around) since the CI changes' ldflags/coverage-reporting steps aren't needed for this to work standalone; this PR is self-contained and mergeable on its own.