### PR TITLE
ci(renovate): fix status writes and run after merges

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,6 +1,9 @@
 name: Renovate
 
 on:
+  push:
+    branches:
+      - main
   schedule:
     - cron: '0 */6 * * *'
   pull_request:
@@ -11,8 +14,8 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  group: renovate-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false  # renovate runs shouldn't be interrupted mid-update
 
 # Read-only. Renovate's repository init reads PRs/issues even in dry-run
 # mode; a bare contents:read zeroes those scopes and fails with

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -57,7 +57,7 @@ jobs:
           permission-pull-requests: write
           permission-workflows: write
           permission-checks: read
-          permission-statuses: read
+          permission-statuses: write
 
       # The dry-run resolves the config *name* from the default branch, so it
       # cannot work until renovate.json exists there (bootstrap PRs would fail


### PR DESCRIPTION
Run self-hosted Renovate after every update to `main` and serialize runs per ref without interrupting an active update. Grant the App token commit-status write access so Renovate can publish `renovate/stability-days` and finish opening dependency PRs.

Validated with the repository's `actionlint`, `yamllint`, and `zizmor` pre-commit checks.
