### PR TITLE
ci(renovate): fix status checks and alert access

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -61,6 +61,7 @@ jobs:
           permission-workflows: write
           permission-checks: read
           permission-statuses: write
+          permission-vulnerability-alerts: read
 
       # The dry-run resolves the config *name* from the default branch, so it
       # cannot work until renovate.json exists there (bootstrap PRs would fail

--- a/mise.toml
+++ b/mise.toml
@@ -12,5 +12,5 @@ yamllint = "1.38.0"
 zizmor = "1.26.1"
 
 node = "24.17.0"
-"npm:renovate" = "43.233.3"
+"npm:renovate" = "43.263.6"
 "npm:release-please" = "17.9.0"


### PR DESCRIPTION
## Summary

- upgrade self-hosted Renovate from 43.233.3 to 43.263.6
- grant the narrowed GitHub App token read-only Dependabot alert access

## Why

Renovate 43.233.3 generated a relative stability-status target URL that GitHub rejected with HTTP 422, then masked that response as `repository-changed`. The upstream fixes landed in [renovatebot/renovate#44126](https://github.com/renovatebot/renovate/pull/44126) and [renovatebot/renovate#44259](https://github.com/renovatebot/renovate/pull/44259); both are included in 43.263.6.

The App registration grants Dependabot-alert reads, but the workflow-scoped installation token did not request that permission. GitHub's 403 response required `vulnerability_alerts=read`.

## Validation

- [Run 29888067423](https://github.com/sosheskaz/healthchecksio-cli/actions/runs/29888067423) completed repository processing with Renovate 43.263.6 and opened [the Go 1.26.5 update](https://github.com/sosheskaz/healthchecksio-cli/pull/77).
- [Run 29888665020](https://github.com/sosheskaz/healthchecksio-cli/actions/runs/29888665020) completed repository processing with read access to vulnerability alerts and no access warning.
- `actionlint`
- `yamllint`
- `zizmor`
- `renovate-config-validator`
