### PR TITLE
ci(mise): shell out to npm CLI to fix aube dependency resolution

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,9 @@
+# mise 2026.7.12 switched the npm backend to install in-process via embedded
+# aube, which fails to resolve deps for renovate/release-please. Route npm
+# installs back through the npm CLI until the aube resolver handles them.
+[settings]
+npm.shell_out = true
+
 [tools]
 go = "1.26.5"
 golangci-lint = "2.12.2"


### PR DESCRIPTION
`main` CI is red: the `go` and `Pre-commit hooks` jobs fail at the mise tool-install step with `aube install failed: failed to resolve dependencies` for `npm:renovate` and `npm:release-please`. This routes npm installs back through the npm CLI to restore working installs.

## Why

mise `2026.7.12` (which CI auto-updated to on 2026-07-23) changed the default npm backend to install **in-process via the embedded aube package manager** instead of shelling out to the `npm` CLI. aube's resolver fails on `renovate`/`release-please`. This is unrelated to the renovate version bump in #93 — the *unchanged* `release-please@17.10.3` fails too, which is what points at the backend, not the package version.

mise ships `npm.shell_out` as the escape hatch for exactly this. `node = 24.18.0` is already pinned, so the `npm` CLI is available.

## Verification (local, on mise 2026.7.12)

Reproduced the exact CI failure and confirmed the fix with a cold A/B install:

| Backend | Result |
| --- | --- |
| `shell_out=false` (aube in-process — 2026.7.12 default) | fails: `aube install failed: failed to resolve dependencies` |
| `shell_out=true` (npm CLI) | installs cleanly: release-please (162 pkgs), renovate (610 pkgs) |

## Design

Chose `npm.shell_out = true` (adapt via the upstream-provided setting) over pinning `MISE_VERSION` to a pre-`2026.7.12` release. The pin would freeze all mise updates and needs manual bumping; the setting is narrow and lets the resolver take over again once aube handles these packages (the comment in `mise.toml` flags that intent).

## Caveats

Fix is validated locally on `macos-arm64`; this PR's own CI run is the Linux confirmation. Unblocks #94 (LICENSE), which is stuck on the same red main.