### PR TITLE
feat: support configuration from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,22 @@ Usage:
 healthchecksio-cli <check_id> [<signal>]
 ```
 
+The check ID can also be supplied with `HEALTHCHECKSIO_CHECK_ID`:
+
+```bash
+HEALTHCHECKSIO_CHECK_ID=<check_id> healthchecksio-cli [<signal>]
+```
+
 or run a command and report its exit status:
 
 ```bash
 healthchecksio-cli exec --check <check_id> -- <command> [args...]
+```
+
+or:
+
+```bash
+HEALTHCHECKSIO_CHECK_ID=<check_id> healthchecksio-cli exec -- <command> [args...]
 ```
 
 or
@@ -22,6 +34,21 @@ docker run --rm ghcr.io/sosheskaz/healthchecksio-cli <check_id> [<signal>]
 
 `signal` is optional. Supported values are `start`, `success`, `failure`, `fail`, `true`, `false`,
 `log`, or a numeric exit status.
+
+## Environment configuration
+
+Explicit flags and positional arguments override environment variables. Environment variables
+override compiled defaults. An empty environment variable is treated as unset.
+
+| Environment variable | Equivalent input | Default |
+| --- | --- | --- |
+| `HEALTHCHECKSIO_CHECK_ID` | `<check_id>` or `exec --check` | None |
+| `HEALTHCHECKSIO_ATTEMPTS` | `--attempts` | `5` |
+| `HEALTHCHECKSIO_RETRY_MAX_BACKOFF` | `--retry-max-backoff` | `30s` |
+| `HEALTHCHECKSIO_CONNECTION_TIMEOUT` | `--connection-timeout` | `5s` |
+| `HEALTHCHECKSIO_TOTAL_PING_TIMEOUT` | `--total-ping-timeout` | `5m` |
+
+Duration values use Go duration syntax, such as `500ms`, `30s`, or `5m`.
 
 ## Retry and timeout options
 

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -1,0 +1,96 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var errInvalidEnvironmentValue = errors.New("invalid environment variable value")
+
+const (
+	envCheckID           = "HEALTHCHECKSIO_CHECK_ID"
+	envAttempts          = "HEALTHCHECKSIO_ATTEMPTS"
+	envRetryMaxBackoff   = "HEALTHCHECKSIO_RETRY_MAX_BACKOFF"
+	envConnectionTimeout = "HEALTHCHECKSIO_CONNECTION_TIMEOUT"
+	envTotalPingTimeout  = "HEALTHCHECKSIO_TOTAL_PING_TIMEOUT"
+)
+
+type envFlagBinding struct {
+	environment string
+	flag        string
+}
+
+type environmentSourcesKey struct{}
+
+var envFlagBindings = []envFlagBinding{
+	{environment: envCheckID, flag: "check"},
+	{environment: envAttempts, flag: "attempts"},
+	{environment: envRetryMaxBackoff, flag: "retry-max-backoff"},
+	{environment: envConnectionTimeout, flag: "connection-timeout"},
+	{environment: envTotalPingTimeout, flag: "total-ping-timeout"},
+}
+
+func bindEnvironment(cmd *cobra.Command) error {
+	flags := cmd.Flags()
+	sources := make(map[string]string)
+	for _, binding := range envFlagBindings {
+		flag := flags.Lookup(binding.flag)
+		if flag == nil || flag.Changed {
+			continue
+		}
+
+		value, ok := os.LookupEnv(binding.environment)
+		if !ok || value == "" {
+			continue
+		}
+		if err := flags.Set(binding.flag, value); err != nil {
+			return invalidEnvironmentValueError(binding.environment, flag.Value.Type())
+		}
+		sources[binding.flag] = binding.environment
+	}
+	cmd.SetContext(context.WithValue(cmd.Context(), environmentSourcesKey{}, sources))
+
+	return nil
+}
+
+func environmentSource(cmd *cobra.Command, flag string) string {
+	sources, ok := cmd.Context().Value(environmentSourcesKey{}).(map[string]string)
+	if !ok {
+		return ""
+	}
+	return sources[flag]
+}
+
+func invalidEnvironmentValueError(environment, expected string) error {
+	return fmt.Errorf("%w: %s expects %s", errInvalidEnvironmentValue, environment, expected)
+}
+
+func environmentPingValidationError(cmd *cobra.Command, validationErr error) error {
+	var flag string
+	switch {
+	case errors.Is(validationErr, errNegativeAttempts):
+		flag = "attempts"
+	case errors.Is(validationErr, errNonPositiveBackoff):
+		flag = "retry-max-backoff"
+	case errors.Is(validationErr, errNonPositiveConnection):
+		flag = "connection-timeout"
+	case errors.Is(validationErr, errNonPositivePingTimeout):
+		flag = "total-ping-timeout"
+	default:
+		return validationErr
+	}
+
+	environment := environmentSource(cmd, flag)
+	if environment == "" {
+		return validationErr
+	}
+	return fmt.Errorf("%w: %s: %w", errInvalidEnvironmentValue, environment, validationErr)
+}
+
+func environmentCheckID() string {
+	return os.Getenv(envCheckID)
+}

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -57,6 +57,13 @@ func bindEnvironment(cmd *cobra.Command) error {
 	return nil
 }
 
+func bindAndValidatePingEnvironment(cmd *cobra.Command, pingOpts *pingOptions) error {
+	if err := bindEnvironment(cmd); err != nil {
+		return err
+	}
+	return environmentPingValidationError(cmd, pingOpts.validate())
+}
+
 func environmentSource(cmd *cobra.Command, flag string) string {
 	sources, ok := cmd.Context().Value(environmentSourcesKey{}).(map[string]string)
 	if !ok {

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -16,11 +16,13 @@ func execCommand(pingOpts *pingOptions, clientFactory pingClientFactory) *cobra.
 	c := &cobra.Command{
 		Use:   "exec [flags] [command...]",
 		Short: "Execute a command and report its status to healthchecks.io",
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
+			return bindAndValidatePingEnvironment(cmd, pingOpts)
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			checkID := cmd.Flag("check").Value.String()
 			if checkID == "" {
-				cmd.Println("Please provide a check id")
-				return nil
+				return &invalidCLIArgsError{Arg: "check", Problem: "check id not provided"}
 			}
 			checkUUID, err := uuid.Parse(checkID)
 			if err != nil {

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -16,15 +16,18 @@ func execCommand(pingOpts *pingOptions, clientFactory pingClientFactory) *cobra.
 	c := &cobra.Command{
 		Use:   "exec [flags] [command...]",
 		Short: "Execute a command and report its status to healthchecks.io",
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			checkID := cmd.Flag("check").Value.String()
 			if checkID == "" {
 				cmd.Println("Please provide a check id")
-				return
+				return nil
 			}
 			checkUUID, err := uuid.Parse(checkID)
 			if err != nil {
-				panic(fmt.Sprintf("check ID %q is not a valid UUID: %+v", checkID, err))
+				if environment := environmentSource(cmd, "check"); environment != "" {
+					return invalidEnvironmentValueError(environment, "a valid UUID")
+				}
+				return fmt.Errorf("check ID is not a valid UUID: %w", err)
 			}
 
 			subcommand := exec.CommandContext(cmd.Context(), args[0], args[1:]...) //nolint:gosec // user-provided command
@@ -69,10 +72,11 @@ func execCommand(pingOpts *pingOptions, clientFactory pingClientFactory) *cobra.
 				os.Exit(exitCode)
 			}
 			mustWrite(cmd.ErrOrStderr(), "check succeeded\n")
+			return nil
 		},
 	}
 
-	c.Flags().StringP("check", "c", "", "The check id to be used")
+	c.Flags().StringP("check", "c", "", "The check id to be used (env: "+envCheckID+")")
 	if err := c.MarkFlagRequired("check"); err != nil {
 		panic(err)
 	}

--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -10,17 +10,38 @@ import (
 	"os/exec"
 	"reflect"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/sosheskaz/healthchecksio-cli/internal/hc"
 )
 
 const execCommandHelperEnv = "HEALTHCHECKSIO_CLI_EXEC_HELPER"
 
 func TestExecCommandReportsSubcommandExitCode(t *testing.T) {
 	t.Parallel()
+
+	tests := []struct {
+		name       string
+		helperMode string
+	}{
+		{name: "check flag", helperMode: "exec"},
+		{name: "environment check ID", helperMode: "exec-env"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			testExecCommandReportsSubcommandExitCode(t, tc.helperMode)
+		})
+	}
+}
+
+func testExecCommandReportsSubcommandExitCode(t *testing.T, helperMode string) {
+	t.Helper()
 
 	checkID := uuid.MustParse("00000000-0000-4000-8000-000000000007")
 	var (
@@ -40,7 +61,7 @@ func TestExecCommandReportsSubcommandExitCode(t *testing.T) {
 		os.Args[0],
 		"-test.run=TestExecCommandHelper",
 		"--",
-		"exec",
+		helperMode,
 		server.URL,
 		checkID.String(),
 	)
@@ -68,6 +89,75 @@ func TestExecCommandReportsSubcommandExitCode(t *testing.T) {
 	}
 }
 
+func TestExecCommandNamesInvalidEnvironmentCheckIDWithoutPanicking(t *testing.T) {
+	const invalidCheckID = "sensitive-invalid-check-id"
+	t.Setenv(envCheckID, invalidCheckID)
+
+	factoryCalled := false
+	cmd := rootCommandWithClientFactory(func(hc.RetryConfig) (*http.Client, error) {
+		factoryCalled = true
+		return http.DefaultClient, nil
+	})
+	cmd.SetArgs([]string{"exec", "--", os.Args[0], "-test.run=^$"})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			t.Errorf("Execute() panicked for invalid %s: %v", envCheckID, recovered)
+		}
+	}()
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want error")
+	}
+	if !errors.Is(err, errInvalidEnvironmentValue) {
+		t.Errorf("Execute() error = %v, want invalid environment value", err)
+	}
+	if !strings.Contains(err.Error(), envCheckID) {
+		t.Errorf("Execute() error = %q, want environment name %q", err, envCheckID)
+	}
+	if strings.Contains(err.Error(), invalidCheckID) {
+		t.Errorf("Execute() error exposed environment value: %v", err)
+	}
+	if factoryCalled {
+		t.Fatal("client factory called for invalid check ID")
+	}
+}
+
+func TestExecCheckFlagOverridesEnvironmentCheckID(t *testing.T) {
+	checkID := uuid.MustParse("00000000-0000-4000-8000-000000000020")
+	t.Setenv(envCheckID, "invalid-environment-check-id")
+
+	requestPaths := make(chan string, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPaths <- r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	cmd := rootCommandWithClientFactory(routeHealthchecksTo(t, server.URL))
+	cmd.SetArgs([]string{
+		"exec",
+		"--check", checkID.String(),
+		"--",
+		os.Args[0],
+		"-test.run=^$",
+	})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	gotPaths := []string{<-requestPaths, <-requestPaths}
+	wantPaths := []string{"/" + checkID.String() + "/start", "/" + checkID.String() + "/0"}
+	if !reflect.DeepEqual(gotPaths, wantPaths) {
+		t.Fatalf("request paths = %v, want %v", gotPaths, wantPaths)
+	}
+}
+
 //nolint:paralleltest // helper subprocess mutates process-wide transport and exits intentionally.
 func TestExecCommandHelper(t *testing.T) {
 	if os.Getenv(execCommandHelperEnv) != "1" {
@@ -83,11 +173,14 @@ func TestExecCommandHelper(t *testing.T) {
 	}
 
 	switch args[1] {
-	case "exec":
+	case "exec", "exec-env":
 		if len(args) != 4 {
-			t.Fatalf("exec helper got args %v, want exec <server-url> <check-id>", args[1:])
+			t.Fatalf("exec helper got args %v, want %s <server-url> <check-id>", args[1:], args[1])
 		}
-		runExecCommandHelper(t, args[2], args[3])
+		if args[1] == "exec-env" {
+			t.Setenv(envCheckID, args[3])
+		}
+		runExecCommandHelper(t, args[2], args[3], args[1] == "exec-env")
 	case "exit":
 		if len(args) != 3 {
 			t.Fatalf("exit helper got args %v, want exit <code>", args[1:])
@@ -116,16 +209,19 @@ func TestExecCommandHelper(t *testing.T) {
 	}
 }
 
-func runExecCommandHelper(t *testing.T, serverURL, checkID string) {
+func runExecCommandHelper(t *testing.T, serverURL, checkID string, useEnvironment bool) {
 	t.Helper()
 
 	cmd := rootCommandWithClientFactory(routeHealthchecksTo(t, serverURL))
-	cmd.SetArgs([]string{
+	args := []string{
 		"exec",
 		"--total-ping-timeout",
 		"25ms",
-		"--check",
-		checkID,
+	}
+	if !useEnvironment {
+		args = append(args, "--check", checkID)
+	}
+	args = append(args,
 		"--",
 		os.Args[0],
 		"-test.run=TestExecCommandHelper",
@@ -133,7 +229,8 @@ func runExecCommandHelper(t *testing.T, serverURL, checkID string) {
 		"sleep-exit",
 		"100ms",
 		"7",
-	})
+	)
+	cmd.SetArgs(args)
 	cmd.SetOut(&bytes.Buffer{})
 	cmd.SetErr(&bytes.Buffer{})
 

--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -158,6 +158,26 @@ func TestExecCheckFlagOverridesEnvironmentCheckID(t *testing.T) {
 	}
 }
 
+func TestExecCommandRejectsEmptyCheckFlag(t *testing.T) {
+	t.Parallel()
+
+	factoryCalled := false
+	cmd := rootCommandWithClientFactory(func(hc.RetryConfig) (*http.Client, error) {
+		factoryCalled = true
+		return http.DefaultClient, nil
+	})
+	cmd.SetArgs([]string{"exec", "--check=", "--", os.Args[0], "-test.run=^$"})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("Execute() error = nil, want empty check flag error")
+	}
+	if factoryCalled {
+		t.Fatal("client factory called for empty check flag")
+	}
+}
+
 //nolint:paralleltest // helper subprocess mutates process-wide transport and exits intentionally.
 func TestExecCommandHelper(t *testing.T) {
 	if os.Getenv(execCommandHelperEnv) != "1" {

--- a/cmd/http_test.go
+++ b/cmd/http_test.go
@@ -86,6 +86,220 @@ func TestRootCommandPassesCustomRetryConfiguration(t *testing.T) {
 	}
 }
 
+func TestRootCommandPassesEnvironmentRetryConfiguration(t *testing.T) {
+	checkID := uuid.MustParse("00000000-0000-4000-8000-000000000015")
+	t.Setenv(envCheckID, checkID.String())
+	t.Setenv(envAttempts, "0")
+	t.Setenv(envRetryMaxBackoff, "13s")
+	t.Setenv(envConnectionTimeout, "4s")
+	t.Setenv(envTotalPingTimeout, "8s")
+
+	configCh := make(chan hc.RetryConfig, 1)
+	deadlineCh := make(chan time.Time, 1)
+	factory := func(config hc.RetryConfig) (*http.Client, error) {
+		configCh <- config
+		return &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			deadline, ok := req.Context().Deadline()
+			if !ok {
+				t.Error("request context has no deadline")
+			}
+			deadlineCh <- deadline
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader(nil)),
+				Request:    req,
+			}, nil
+		})}, nil
+	}
+
+	started := time.Now()
+	cmd := rootCommandWithClientFactory(factory)
+	cmd.SetArgs(nil)
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	config := <-configCh
+	if config.Attempts != 0 || config.MaxBackoff != 13*time.Second || config.ConnectionTimeout != 4*time.Second {
+		t.Fatalf("retry config = %+v, want attempts 0, backoff 13s, connection timeout 4s", config)
+	}
+	remaining := (<-deadlineCh).Sub(started)
+	if remaining < 7*time.Second || remaining > 9*time.Second {
+		t.Fatalf("request deadline remaining = %s, want approximately 8s", remaining)
+	}
+}
+
+func TestFlagsOverrideEnvironmentRetryConfiguration(t *testing.T) {
+	t.Setenv(envAttempts, "not-an-int")
+	t.Setenv(envRetryMaxBackoff, "not-a-duration")
+	t.Setenv(envConnectionTimeout, "not-a-duration")
+	t.Setenv(envTotalPingTimeout, "not-a-duration")
+
+	configCh := make(chan hc.RetryConfig, 1)
+	factory := func(config hc.RetryConfig) (*http.Client, error) {
+		configCh <- config
+		return &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader(nil)),
+				Request:    req,
+			}, nil
+		})}, nil
+	}
+
+	cmd := rootCommandWithClientFactory(factory)
+	cmd.SetArgs([]string{
+		"--attempts", "2",
+		"--retry-max-backoff", "14s",
+		"--connection-timeout", "6s",
+		"--total-ping-timeout", "9s",
+		uuid.MustParse("00000000-0000-4000-8000-000000000016").String(),
+	})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	config := <-configCh
+	if config.Attempts != 2 || config.MaxBackoff != 14*time.Second || config.ConnectionTimeout != 6*time.Second {
+		t.Fatalf("retry config = %+v, want attempts 2, backoff 14s, connection timeout 6s", config)
+	}
+}
+
+func TestRootCommandRejectsMalformedEnvironmentRetryConfiguration(t *testing.T) {
+	tests := []struct {
+		name        string
+		environment string
+	}{
+		{name: "attempts", environment: envAttempts},
+		{name: "retry maximum backoff", environment: envRetryMaxBackoff},
+		{name: "connection timeout", environment: envConnectionTimeout},
+		{name: "total ping timeout", environment: envTotalPingTimeout},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			const invalidValue = "sensitive-invalid-value"
+			for _, binding := range envFlagBindings {
+				t.Setenv(binding.environment, "")
+			}
+			t.Setenv(tc.environment, invalidValue)
+
+			factoryCalled := false
+			cmd := rootCommandWithClientFactory(func(hc.RetryConfig) (*http.Client, error) {
+				factoryCalled = true
+				return http.DefaultClient, nil
+			})
+			cmd.SetArgs([]string{uuid.MustParse("00000000-0000-4000-8000-000000000017").String()})
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatal("Execute() error = nil, want error")
+			}
+			if !strings.Contains(err.Error(), tc.environment) {
+				t.Fatalf("Execute() error = %q, want environment name %q", err, tc.environment)
+			}
+			if strings.Contains(err.Error(), invalidValue) {
+				t.Fatalf("Execute() error exposed environment value: %v", err)
+			}
+			if factoryCalled {
+				t.Fatal("client factory called for invalid configuration")
+			}
+		})
+	}
+}
+
+func TestRootCommandNamesSemanticallyInvalidEnvironmentRetryConfiguration(t *testing.T) {
+	tests := []struct {
+		name        string
+		environment string
+		value       string
+	}{
+		{name: "negative attempts", environment: envAttempts, value: "-1"},
+		{name: "zero retry maximum backoff", environment: envRetryMaxBackoff, value: "0s"},
+		{name: "zero connection timeout", environment: envConnectionTimeout, value: "0s"},
+		{name: "zero total ping timeout", environment: envTotalPingTimeout, value: "0s"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(tc.environment, tc.value)
+
+			factoryCalled := false
+			cmd := rootCommandWithClientFactory(func(hc.RetryConfig) (*http.Client, error) {
+				factoryCalled = true
+				return http.DefaultClient, nil
+			})
+			cmd.SetArgs([]string{uuid.MustParse("00000000-0000-4000-8000-000000000018").String()})
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatal("Execute() error = nil, want error")
+			}
+			if !errors.Is(err, errInvalidEnvironmentValue) {
+				t.Errorf("Execute() error = %v, want invalid environment value", err)
+			}
+			if !strings.Contains(err.Error(), tc.environment) {
+				t.Errorf("Execute() error = %q, want environment name %q", err, tc.environment)
+			}
+			if strings.Contains(err.Error(), tc.value) {
+				t.Errorf("Execute() error exposed environment value: %v", err)
+			}
+			if factoryCalled {
+				t.Fatal("client factory called for invalid configuration")
+			}
+		})
+	}
+}
+
+func TestEmptyEnvironmentRetryConfigurationUsesDefaults(t *testing.T) {
+	t.Setenv(envAttempts, "")
+	t.Setenv(envRetryMaxBackoff, "")
+	t.Setenv(envConnectionTimeout, "")
+	t.Setenv(envTotalPingTimeout, "")
+
+	configCh := make(chan hc.RetryConfig, 1)
+	deadlineCh := make(chan time.Time, 1)
+	factory := func(config hc.RetryConfig) (*http.Client, error) {
+		configCh <- config
+		return &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			deadline, ok := req.Context().Deadline()
+			if !ok {
+				t.Error("request context has no deadline")
+			}
+			deadlineCh <- deadline
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader(nil)),
+				Request:    req,
+			}, nil
+		})}, nil
+	}
+
+	started := time.Now()
+	cmd := rootCommandWithClientFactory(factory)
+	cmd.SetArgs([]string{uuid.MustParse("00000000-0000-4000-8000-000000000019").String()})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	config := <-configCh
+	if config.Attempts != defaultAttempts || config.MaxBackoff != defaultRetryMaxBackoff || config.ConnectionTimeout != defaultConnectionTimeout {
+		t.Fatalf("retry config = %+v, want defaults", config)
+	}
+	remaining := (<-deadlineCh).Sub(started)
+	if remaining < defaultTotalPingTimeout-time.Second || remaining > defaultTotalPingTimeout+time.Second {
+		t.Fatalf("request deadline remaining = %s, want approximately %s", remaining, defaultTotalPingTimeout)
+	}
+}
+
 func TestRootCommandRejectsInvalidPingOptions(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/http_test.go
+++ b/cmd/http_test.go
@@ -114,7 +114,7 @@ func TestRootCommandPassesEnvironmentRetryConfiguration(t *testing.T) {
 
 	started := time.Now()
 	cmd := rootCommandWithClientFactory(factory)
-	cmd.SetArgs(nil)
+	cmd.SetArgs([]string{})
 	cmd.SetOut(&bytes.Buffer{})
 	cmd.SetErr(&bytes.Buffer{})
 	if err := cmd.Execute(); err != nil {

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,17 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	for _, binding := range envFlagBindings {
+		if err := os.Unsetenv(binding.environment); err != nil {
+			panic(fmt.Sprintf("unset %s: %v", binding.environment, err))
+		}
+	}
+
+	os.Exit(m.Run())
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -86,11 +86,8 @@ func rootCommandWithClientFactory(clientFactory pingClientFactory) *cobra.Comman
 		Use:     "healthchecksio-cli [<check_id>] [<signal>]",
 		Short:   "Call healthchecks.io checks from the command line",
 		Version: version.Get().String(),
-		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
-			if err := bindEnvironment(cmd); err != nil {
-				return err
-			}
-			return environmentPingValidationError(cmd, pingOpts.validate())
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
+			return bindAndValidatePingEnvironment(cmd, pingOpts)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			checkID, signal, checkIDEnvironment := directPingArguments(args)
@@ -174,6 +171,9 @@ func directPingArguments(args []string) (string, string, string) {
 		}
 		return checkID, "", envCheckID
 	case 1:
+		if args[0] == "" {
+			return "", "", ""
+		}
 		if _, err := uuid.Parse(args[0]); err == nil {
 			return args[0], "", ""
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,10 +27,10 @@ func (e *invalidCLIArgsError) Error() string {
 var topCommands = make([]func(*pingOptions, pingClientFactory) *cobra.Command, 0)
 
 func rootCmdUsage() string {
-	return fmt.Sprintf(`Usage: %s <check_id> [<signal>]
-  <check_id> - The check id to be used
+	return fmt.Sprintf(`Usage: %s [<check_id>] [<signal>]
+  <check_id> - The check id to be used (or set %s)
   <signal> - The signal to be sent, if any. Example: start, success, <return-code>, etc. See the docs for more details.
-`, os.Args[0])
+`, os.Args[0], envCheckID)
 }
 
 func mustWrite(w io.Writer, msg string) {
@@ -83,32 +83,26 @@ func rootCommand() *cobra.Command {
 func rootCommandWithClientFactory(clientFactory pingClientFactory) *cobra.Command {
 	pingOpts := defaultPingOptions()
 	c := &cobra.Command{
-		Use:     "healthchecksio-cli <check_id> [<signal>]",
+		Use:     "healthchecksio-cli [<check_id>] [<signal>]",
 		Short:   "Call healthchecks.io checks from the command line",
 		Version: version.Get().String(),
-		PersistentPreRunE: func(*cobra.Command, []string) error {
-			return pingOpts.validate()
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			if err := bindEnvironment(cmd); err != nil {
+				return err
+			}
+			return environmentPingValidationError(cmd, pingOpts.validate())
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			var (
-				checkID string
-				signal  string
-			)
-
-			if len(args) == 0 {
+			checkID, signal, checkIDEnvironment := directPingArguments(args)
+			if checkID == "" {
 				mustWrite(cmd.ErrOrStderr(), rootCmdUsage())
 				return &invalidCLIArgsError{"posargs", "check_id not provided"}
 			}
-			if len(args) > 2 {
-				mustWrite(cmd.ErrOrStderr(), rootCmdUsage())
-				return &invalidCLIArgsError{"posargs", "too many arguments"}
-			}
-			checkID = args[0]
-			if len(args) > 1 {
-				signal = args[1]
-			}
 			checkUUID, err := uuid.Parse(checkID)
 			if err != nil {
+				if checkIDEnvironment != "" {
+					return invalidEnvironmentValueError(checkIDEnvironment, "a valid UUID")
+				}
 				return fmt.Errorf("invalid check_id: %w", err)
 			}
 
@@ -144,16 +138,52 @@ func rootCommandWithClientFactory(clientFactory pingClientFactory) *cobra.Comman
 		&pingOpts.attempts,
 		"attempts",
 		defaultAttempts,
-		"Total HTTP attempts per ping (0 to retry indefinitely within the total ping timeout)",
+		"Total HTTP attempts per ping (0 to retry indefinitely within the total ping timeout; env: "+envAttempts+")",
 	)
-	c.PersistentFlags().DurationVar(&pingOpts.retryMaxBackoff, "retry-max-backoff", defaultRetryMaxBackoff, "Maximum delay between ping attempts")
-	c.PersistentFlags().DurationVar(&pingOpts.connectionTimeout, "connection-timeout", defaultConnectionTimeout, "Timeout for ping connection and TLS setup")
-	c.PersistentFlags().DurationVar(&pingOpts.totalPingTimeout, "total-ping-timeout", defaultTotalPingTimeout, "Total timeout for each ping operation")
+	c.PersistentFlags().DurationVar(
+		&pingOpts.retryMaxBackoff,
+		"retry-max-backoff",
+		defaultRetryMaxBackoff,
+		"Maximum delay between ping attempts (env: "+envRetryMaxBackoff+")",
+	)
+	c.PersistentFlags().DurationVar(
+		&pingOpts.connectionTimeout,
+		"connection-timeout",
+		defaultConnectionTimeout,
+		"Timeout for ping connection and TLS setup (env: "+envConnectionTimeout+")",
+	)
+	c.PersistentFlags().DurationVar(
+		&pingOpts.totalPingTimeout,
+		"total-ping-timeout",
+		defaultTotalPingTimeout,
+		"Total timeout for each ping operation (env: "+envTotalPingTimeout+")",
+	)
 
 	c.InitDefaultCompletionCmd()
-	c.Args = cobra.RangeArgs(1, 2)
+	c.Args = cobra.MaximumNArgs(2)
 
 	return c
+}
+
+func directPingArguments(args []string) (string, string, string) {
+	switch len(args) {
+	case 0:
+		checkID := environmentCheckID()
+		if checkID == "" {
+			return "", "", ""
+		}
+		return checkID, "", envCheckID
+	case 1:
+		if _, err := uuid.Parse(args[0]); err == nil {
+			return args[0], "", ""
+		}
+		if checkID := environmentCheckID(); checkID != "" {
+			return checkID, args[0], envCheckID
+		}
+		return args[0], "", ""
+	default:
+		return args[0], args[1], ""
+	}
 }
 
 // Command returns the root command for the healthchecksio-cli application.

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -2,10 +2,12 @@ package cmd
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -68,5 +70,122 @@ func TestRootCommandAcceptsStartSignal(t *testing.T) {
 
 	if got, want := <-requestPath, "/"+checkID.String()+"/start"; got != want {
 		t.Fatalf("request path = %q, want %q", got, want)
+	}
+}
+
+func TestRootCommandAcceptsEnvironmentCheckIDAndSignal(t *testing.T) {
+	checkID := uuid.MustParse("00000000-0000-4000-8000-000000000012")
+	t.Setenv(envCheckID, checkID.String())
+
+	requestPath := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPath <- r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	cmd := rootCommandWithClientFactory(routeHealthchecksTo(t, server.URL))
+	cmd.SetArgs([]string{"start"})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if got, want := <-requestPath, "/"+checkID.String()+"/start"; got != want {
+		t.Fatalf("request path = %q, want %q", got, want)
+	}
+}
+
+func TestDirectPingArguments(t *testing.T) {
+	environmentID := uuid.MustParse("00000000-0000-4000-8000-000000000013").String()
+	positionalID := uuid.MustParse("00000000-0000-4000-8000-000000000014").String()
+
+	tests := []struct {
+		name        string
+		environment string
+		arguments   string
+		wantCheckID string
+		wantSignal  string
+		wantSource  string
+	}{
+		{name: "environment success", environment: environmentID, wantCheckID: environmentID, wantSource: envCheckID},
+		{name: "environment signal", environment: environmentID, arguments: "failure", wantCheckID: environmentID, wantSignal: "failure", wantSource: envCheckID},
+		{name: "positional override", environment: environmentID, arguments: positionalID, wantCheckID: positionalID},
+		{name: "positional check and signal", environment: environmentID, arguments: positionalID + " start", wantCheckID: positionalID, wantSignal: "start"},
+		{name: "missing", wantCheckID: ""},
+		{name: "invalid positional without environment", arguments: "not-a-uuid", wantCheckID: "not-a-uuid"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(envCheckID, tc.environment)
+
+			args := strings.Fields(tc.arguments)
+			checkID, signal, source := directPingArguments(args)
+			if checkID != tc.wantCheckID || signal != tc.wantSignal || source != tc.wantSource {
+				t.Fatalf(
+					"directPingArguments(%v) = (%q, %q, %q), want (%q, %q, %q)",
+					args,
+					checkID,
+					signal,
+					source,
+					tc.wantCheckID,
+					tc.wantSignal,
+					tc.wantSource,
+				)
+			}
+		})
+	}
+}
+
+func TestRootCommandRejectsInvalidEnvironmentCheckIDWithoutExposingIt(t *testing.T) {
+	const invalidCheckID = "sensitive-invalid-check-id"
+	t.Setenv(envCheckID, invalidCheckID)
+
+	factoryCalled := false
+	cmd := rootCommandWithClientFactory(func(hc.RetryConfig) (*http.Client, error) {
+		factoryCalled = true
+		return http.DefaultClient, nil
+	})
+	cmd.SetArgs(nil)
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want error")
+	}
+	if !errors.Is(err, errInvalidEnvironmentValue) {
+		t.Errorf("Execute() error = %v, want invalid environment value", err)
+	}
+	if !strings.Contains(err.Error(), envCheckID) {
+		t.Errorf("Execute() error = %q, want environment name %q", err, envCheckID)
+	}
+	if strings.Contains(err.Error(), invalidCheckID) {
+		t.Fatalf("Execute() error exposed environment value: %v", err)
+	}
+	if factoryCalled {
+		t.Fatal("client factory called for invalid check ID")
+	}
+}
+
+func TestRootCommandTreatsEmptyEnvironmentCheckIDAsUnset(t *testing.T) {
+	t.Setenv(envCheckID, "")
+
+	factoryCalled := false
+	cmd := rootCommandWithClientFactory(func(hc.RetryConfig) (*http.Client, error) {
+		factoryCalled = true
+		return http.DefaultClient, nil
+	})
+	cmd.SetArgs(nil)
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("Execute() error = nil, want missing check ID error")
+	}
+	if factoryCalled {
+		t.Fatal("client factory called without a check ID")
 	}
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -98,6 +98,66 @@ func TestRootCommandAcceptsEnvironmentCheckIDAndSignal(t *testing.T) {
 	}
 }
 
+func TestRootCommandRejectsEmptyPositionalCheckIDWhenEnvironmentIsSet(t *testing.T) {
+	t.Setenv(envCheckID, uuid.MustParse("00000000-0000-4000-8000-000000000021").String())
+
+	factoryCalled := false
+	cmd := rootCommandWithClientFactory(func(hc.RetryConfig) (*http.Client, error) {
+		factoryCalled = true
+		return &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       http.NoBody,
+				Request:    req,
+			}, nil
+		})}, nil
+	})
+	cmd.SetArgs([]string{""})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("Execute() error = nil, want empty positional check ID error")
+	}
+	if factoryCalled {
+		t.Fatal("client factory called for empty positional check ID")
+	}
+}
+
+//nolint:paralleltest // The parent sets process-wide environment for every command case.
+func TestUtilityCommandsIgnoreEnvironmentConfiguration(t *testing.T) {
+	t.Setenv(envAttempts, "invalid")
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "help flag", args: []string{"--help"}},
+		{name: "help command", args: []string{"help"}},
+		{name: "completion command", args: []string{"completion", "bash"}},
+		{name: "completion protocol", args: []string{"__complete", ""}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			factoryCalled := false
+			cmd := rootCommandWithClientFactory(func(hc.RetryConfig) (*http.Client, error) {
+				factoryCalled = true
+				return http.DefaultClient, nil
+			})
+			cmd.SetArgs(tc.args)
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+			if factoryCalled {
+				t.Fatal("client factory called for utility command")
+			}
+		})
+	}
+}
+
 func TestDirectPingArguments(t *testing.T) {
 	environmentID := uuid.MustParse("00000000-0000-4000-8000-000000000013").String()
 	positionalID := uuid.MustParse("00000000-0000-4000-8000-000000000014").String()
@@ -148,7 +208,7 @@ func TestRootCommandRejectsInvalidEnvironmentCheckIDWithoutExposingIt(t *testing
 		factoryCalled = true
 		return http.DefaultClient, nil
 	})
-	cmd.SetArgs(nil)
+	cmd.SetArgs([]string{})
 	cmd.SetOut(&bytes.Buffer{})
 	cmd.SetErr(&bytes.Buffer{})
 
@@ -178,7 +238,7 @@ func TestRootCommandTreatsEmptyEnvironmentCheckIDAsUnset(t *testing.T) {
 		factoryCalled = true
 		return http.DefaultClient, nil
 	})
-	cmd.SetArgs(nil)
+	cmd.SetArgs([]string{})
 	cmd.SetOut(&bytes.Buffer{})
 	cmd.SetErr(&bytes.Buffer{})
 


### PR DESCRIPTION
Adds environment-variable fallbacks for the check ID and retry/timeout settings while preserving explicit CLI and positional precedence. It includes redacted, source-aware validation, direct and `exec` coverage, and documentation; local tests, race detection, lint, module verification, and vulnerability scanning pass.

## Design

Uses a small explicit Cobra/pflag binding layer instead of Viper. This keeps the dependency surface unchanged while reusing existing flag parsing and retaining CLI > environment > default precedence.
