### PR TITLE
fix(cli): omit check UUIDs from progress logs

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -42,7 +42,7 @@ func execCommand(pingOpts *pingOptions, clientFactory pingClientFactory) *cobra.
 				panic(fmt.Sprintf("failed to construct check: %+v", err))
 			}
 
-			mustWrite(cmd.ErrOrStderr(), "starting check "+checkID+"\n")
+			mustWrite(cmd.ErrOrStderr(), "starting check\n")
 			if err := pingOpts.call(cmd.Context(), func(ctx context.Context) error {
 				return check.Start(ctx)
 			}); err != nil {

--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -79,6 +79,12 @@ func testExecCommandReportsSubcommandExitCode(t *testing.T, helperMode string) {
 	if got, want := exitErr.ExitCode(), 7; got != want {
 		t.Fatalf("helper exit code = %d, want %d; stdout: %s; stderr: %s", got, want, stdout.String(), stderr.String())
 	}
+	if strings.Contains(stderr.String(), checkID.String()) {
+		t.Fatalf("helper stderr exposed check ID: %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "starting check\n") {
+		t.Fatalf("helper stderr = %q, want starting check message", stderr.String())
+	}
 
 	mu.Lock()
 	gotPaths := append([]string(nil), requestPaths...)
@@ -252,7 +258,7 @@ func runExecCommandHelper(t *testing.T, serverURL, checkID string, useEnvironmen
 	)
 	cmd.SetArgs(args)
 	cmd.SetOut(&bytes.Buffer{})
-	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetErr(os.Stderr)
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("exec command error = %v", err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -117,7 +117,7 @@ func rootCommandWithClientFactory(clientFactory pingClientFactory) *cobra.Comman
 				return err
 			}
 
-			mustWrite(cmd.ErrOrStderr(), "calling check "+checkID)
+			mustWrite(cmd.ErrOrStderr(), "calling check")
 			if signal != "" {
 				mustWrite(cmd.ErrOrStderr(), " with signal "+signal)
 			}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -62,7 +62,8 @@ func TestRootCommandAcceptsStartSignal(t *testing.T) {
 	cmd := rootCommandWithClientFactory(routeHealthchecksTo(t, server.URL))
 	cmd.SetArgs([]string{checkID.String(), "start"})
 	cmd.SetOut(&bytes.Buffer{})
-	cmd.SetErr(&bytes.Buffer{})
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
@@ -70,6 +71,12 @@ func TestRootCommandAcceptsStartSignal(t *testing.T) {
 
 	if got, want := <-requestPath, "/"+checkID.String()+"/start"; got != want {
 		t.Fatalf("request path = %q, want %q", got, want)
+	}
+	if got, want := stderr.String(), "calling check with signal start\n"; got != want {
+		t.Fatalf("stderr = %q, want %q", got, want)
+	}
+	if strings.Contains(stderr.String(), checkID.String()) {
+		t.Fatalf("stderr exposed check ID: %q", stderr.String())
 	}
 }
 
@@ -87,7 +94,8 @@ func TestRootCommandAcceptsEnvironmentCheckIDAndSignal(t *testing.T) {
 	cmd := rootCommandWithClientFactory(routeHealthchecksTo(t, server.URL))
 	cmd.SetArgs([]string{"start"})
 	cmd.SetOut(&bytes.Buffer{})
-	cmd.SetErr(&bytes.Buffer{})
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
@@ -95,6 +103,38 @@ func TestRootCommandAcceptsEnvironmentCheckIDAndSignal(t *testing.T) {
 
 	if got, want := <-requestPath, "/"+checkID.String()+"/start"; got != want {
 		t.Fatalf("request path = %q, want %q", got, want)
+	}
+	if got, want := stderr.String(), "calling check with signal start\n"; got != want {
+		t.Fatalf("stderr = %q, want %q", got, want)
+	}
+	if strings.Contains(stderr.String(), checkID.String()) {
+		t.Fatalf("stderr exposed check ID from environment: %q", stderr.String())
+	}
+}
+
+func TestRootCommandOmitsCheckIDWithoutSignal(t *testing.T) {
+	t.Parallel()
+
+	checkID := uuid.MustParse("00000000-0000-4000-8000-000000000022")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	cmd := rootCommandWithClientFactory(routeHealthchecksTo(t, server.URL))
+	cmd.SetArgs([]string{checkID.String()})
+	cmd.SetOut(&bytes.Buffer{})
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got, want := stderr.String(), "calling check\n"; got != want {
+		t.Fatalf("stderr = %q, want %q", got, want)
+	}
+	if strings.Contains(stderr.String(), checkID.String()) {
+		t.Fatalf("stderr exposed check ID: %q", stderr.String())
 	}
 }
 


### PR DESCRIPTION
Healthchecks UUIDs may be sensitive, so CLI-generated progress messages should not echo them to stderr. This keeps the existing progress and signal context without printing the check identifier.

## Changes

- Omit the check UUID from direct-ping and `exec` progress messages.
- Add regression coverage for positional, flag, and environment-provided check IDs.

## Caveats

Raw UUIDs in otherwise unchanged propagated request errors remain out of scope.
