### PR TITLE
fix(deps): update Go to 1.26.6

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -5,7 +5,7 @@
 npm.shell_out = true
 
 [tools]
-go = "1.26.5"
+go = "1.26.6"
 golangci-lint = "2.12.2"
 goreleaser = "2.17.1"
 ko = "0.19.1"


### PR DESCRIPTION
Updates the pinned Go toolchain from 1.26.5 to 1.26.6 so the CI vulnerability scan no longer fails on four reachable standard-library vulnerabilities fixed in the patch release.

## Validation

- `go build ./...`
- `go mod tidy -diff -v`
- `go test -shuffle=on -coverprofile=coverage.out -covermode=atomic -coverpkg=./... ./...`
- `go test -race -shuffle=on ./...`
- `go test -run='^$' -bench=. -benchtime=1x ./...`
- `govulncheck ./...` — no vulnerabilities found
- `golangci-lint run` — 0 issues
