### PR TITLE
chore(renovate): disable automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,7 +27,7 @@
       "semanticCommitType": "ci",
       "pinDigests": true,
       "versioning": "semver",
-      "automerge": true
+      "automerge": false
     },
     {
       "matchManagers": ["mise"],
@@ -38,7 +38,7 @@
       "matchManagers": ["mise"],
       "matchDepNames": ["!go"],
       "matchUpdateTypes": ["patch", "minor"],
-      "automerge": true
+      "automerge": false
     },
     {
       "matchManagers": ["gomod"],


### PR DESCRIPTION
Disable Renovate automerge so dependency updates require explicit review and merge.

## Changes

- Disable automerge for GitHub Actions updates.
- Disable automerge for non-Go `mise` patch and minor updates.

## Validation

- `jq empty renovate.json`
- `mise exec -- renovate-config-validator renovate.json`
