### PR TITLE
build: adopt Go 1.27

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -72,8 +72,12 @@ changelog:
 
 kos:
   - repositories: [ghcr.io/sosheskaz/healthchecksio-cli]
-    # Disabled for snapshot builds so PR validation never pushes.
-    disable: "{{ .IsSnapshot }}"
+    # Keep the package explicit: Go 1.27 rejects the empty package path that
+    # older toolchains treated as the current package.
+    main: .
+    # Snapshot releases load into the runner's local Docker daemon, exercising
+    # the Ko integration without publishing to an external registry.
+    local_domain: goreleaser.ko.local
     tags:
       - "{{.Version}}"
       - "{{.Major}}"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A simple CLI for healthchecks.io
 
+Building from source requires Go 1.27 or later. Prebuilt macOS binaries require macOS 13 Ventura or later.
+
 Usage:
 
 ```bash

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"uuid"
 
-	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -14,8 +14,7 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	"github.com/google/uuid"
+	"uuid"
 
 	"github.com/sosheskaz/healthchecksio-cli/internal/hc"
 )
@@ -137,13 +136,13 @@ func TestExecCheckFlagOverridesEnvironmentCheckID(t *testing.T) {
 	t.Setenv(envCheckID, "invalid-environment-check-id")
 
 	requestPaths := make(chan string, 2)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestPaths <- r.URL.Path
 		w.WriteHeader(http.StatusOK)
 	}))
-	t.Cleanup(server.Close)
+	client := server.Client()
 
-	cmd := rootCommandWithClientFactory(routeHealthchecksTo(t, server.URL))
+	cmd := rootCommandWithClientFactory(routeHealthchecksTo(t, server.URL, client.Transport))
 	cmd.SetArgs([]string{
 		"exec",
 		"--check", checkID.String(),
@@ -238,7 +237,7 @@ func TestExecCommandHelper(t *testing.T) {
 func runExecCommandHelper(t *testing.T, serverURL, checkID string, useEnvironment bool) {
 	t.Helper()
 
-	cmd := rootCommandWithClientFactory(routeHealthchecksTo(t, serverURL))
+	cmd := rootCommandWithClientFactory(routeHealthchecksTo(t, serverURL, http.DefaultTransport))
 	args := []string{
 		"exec",
 		"--total-ping-timeout",

--- a/cmd/http.go
+++ b/cmd/http.go
@@ -5,8 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"time"
-
-	"github.com/google/uuid"
+	"uuid"
 
 	"github.com/sosheskaz/healthchecksio-cli/internal/hc"
 )

--- a/cmd/http_test.go
+++ b/cmd/http_test.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
-
-	"github.com/google/uuid"
+	"uuid"
 
 	"github.com/sosheskaz/healthchecksio-cli/internal/hc"
 )
@@ -338,15 +338,21 @@ func TestRootCommandRejectsInvalidPingOptions(t *testing.T) {
 func TestPingOptionsCallEnforcesTotalTimeout(t *testing.T) {
 	t.Parallel()
 
-	opts := defaultPingOptions()
-	opts.totalPingTimeout = 10 * time.Millisecond
-	err := opts.call(t.Context(), func(ctx context.Context) error {
-		<-ctx.Done()
-		return ctx.Err()
+	synctest.Test(t, func(t *testing.T) {
+		opts := defaultPingOptions()
+		opts.totalPingTimeout = 10 * time.Millisecond
+		started := time.Now()
+		err := opts.call(t.Context(), func(ctx context.Context) error {
+			<-ctx.Done()
+			return ctx.Err()
+		})
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("call() error = %v, want context deadline exceeded", err)
+		}
+		if elapsed := time.Since(started); elapsed != 10*time.Millisecond {
+			t.Fatalf("call() elapsed = %s, want 10ms", elapsed)
+		}
 	})
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("call() error = %v, want context deadline exceeded", err)
-	}
 }
 
 func TestRootLogSignal(t *testing.T) {
@@ -386,38 +392,39 @@ func TestRootLogSignal(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+			synctest.Test(t, func(t *testing.T) {
+				var requests atomic.Int32
+				bodyCh := make(chan string, 1)
+				server := httptest.NewTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					requests.Add(1)
+					body, err := io.ReadAll(r.Body)
+					if err != nil {
+						t.Errorf("io.ReadAll() error = %v", err)
+					}
+					bodyCh <- string(body)
+					w.WriteHeader(http.StatusOK)
+				}))
+				client := server.Client()
 
-			var requests atomic.Int32
-			bodyCh := make(chan string, 1)
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				requests.Add(1)
-				body, err := io.ReadAll(r.Body)
-				if err != nil {
-					t.Errorf("io.ReadAll() error = %v", err)
+				checkID := uuid.MustParse("00000000-0000-4000-8000-000000000031")
+				cmd := rootCommandWithClientFactory(routeHealthchecksTo(t, server.URL, client.Transport))
+				cmd.SetArgs([]string{"--total-ping-timeout", tc.timeout.String(), checkID.String(), "log"})
+				cmd.SetIn(tc.input())
+				cmd.SetOut(&bytes.Buffer{})
+				cmd.SetErr(&bytes.Buffer{})
+				err := cmd.Execute()
+				if (err != nil) != tc.wantErr {
+					t.Fatalf("Execute() error = %v, wantErr %v", err, tc.wantErr)
 				}
-				bodyCh <- string(body)
-				w.WriteHeader(http.StatusOK)
-			}))
-			t.Cleanup(server.Close)
-
-			checkID := uuid.MustParse("00000000-0000-4000-8000-000000000031")
-			cmd := rootCommandWithClientFactory(routeHealthchecksTo(t, server.URL))
-			cmd.SetArgs([]string{"--total-ping-timeout", tc.timeout.String(), checkID.String(), "log"})
-			cmd.SetIn(tc.input())
-			cmd.SetOut(&bytes.Buffer{})
-			cmd.SetErr(&bytes.Buffer{})
-			err := cmd.Execute()
-			if (err != nil) != tc.wantErr {
-				t.Fatalf("Execute() error = %v, wantErr %v", err, tc.wantErr)
-			}
-			if got := requests.Load(); got != tc.wantRequests {
-				t.Fatalf("requests = %d, want %d", got, tc.wantRequests)
-			}
-			if tc.wantRequests > 0 {
-				if got := <-bodyCh; got != tc.wantBody {
-					t.Fatalf("body = %q, want %q", got, tc.wantBody)
+				if got := requests.Load(); got != tc.wantRequests {
+					t.Fatalf("requests = %d, want %d", got, tc.wantRequests)
 				}
-			}
+				if tc.wantRequests > 0 {
+					if got := <-bodyCh; got != tc.wantBody {
+						t.Fatalf("body = %q, want %q", got, tc.wantBody)
+					}
+				}
+			})
 		})
 	}
 }
@@ -430,7 +437,7 @@ type delayedReader struct {
 
 func (r *delayedReader) Read(p []byte) (int, error) {
 	if !r.slept {
-		time.Sleep(r.delay)
+		synctest.Sleep(r.delay)
 		r.slept = true
 	}
 	//nolint:wrapcheck // io.Reader must return io.EOF unchanged.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,8 +7,8 @@ import (
 	"io"
 	"os"
 	"strconv"
+	"uuid"
 
-	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
 	"github.com/sosheskaz/healthchecksio-cli/internal/hc"

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -9,8 +9,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
-
-	"github.com/google/uuid"
+	"uuid"
 
 	"github.com/sosheskaz/healthchecksio-cli/internal/hc"
 )
@@ -32,7 +31,7 @@ func (t rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return resp, nil
 }
 
-func routeHealthchecksTo(t *testing.T, targetURL string) pingClientFactory {
+func routeHealthchecksTo(t *testing.T, targetURL string, base http.RoundTripper) pingClientFactory {
 	t.Helper()
 
 	parsed, err := url.Parse(targetURL)
@@ -43,7 +42,7 @@ func routeHealthchecksTo(t *testing.T, targetURL string) pingClientFactory {
 	return func(hc.RetryConfig) (*http.Client, error) {
 		return &http.Client{Transport: rewriteTransport{
 			target: parsed,
-			base:   http.DefaultTransport,
+			base:   base,
 		}}, nil
 	}
 }
@@ -53,13 +52,13 @@ func TestRootCommandAcceptsStartSignal(t *testing.T) {
 
 	checkID := uuid.MustParse("00000000-0000-4000-8000-000000000006")
 	requestPath := make(chan string, 1)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestPath <- r.URL.Path
 		w.WriteHeader(http.StatusOK)
 	}))
-	t.Cleanup(server.Close)
+	client := server.Client()
 
-	cmd := rootCommandWithClientFactory(routeHealthchecksTo(t, server.URL))
+	cmd := rootCommandWithClientFactory(routeHealthchecksTo(t, server.URL, client.Transport))
 	cmd.SetArgs([]string{checkID.String(), "start"})
 	cmd.SetOut(&bytes.Buffer{})
 	var stderr bytes.Buffer
@@ -85,13 +84,13 @@ func TestRootCommandAcceptsEnvironmentCheckIDAndSignal(t *testing.T) {
 	t.Setenv(envCheckID, checkID.String())
 
 	requestPath := make(chan string, 1)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestPath <- r.URL.Path
 		w.WriteHeader(http.StatusOK)
 	}))
-	t.Cleanup(server.Close)
+	client := server.Client()
 
-	cmd := rootCommandWithClientFactory(routeHealthchecksTo(t, server.URL))
+	cmd := rootCommandWithClientFactory(routeHealthchecksTo(t, server.URL, client.Transport))
 	cmd.SetArgs([]string{"start"})
 	cmd.SetOut(&bytes.Buffer{})
 	var stderr bytes.Buffer
@@ -116,12 +115,12 @@ func TestRootCommandOmitsCheckIDWithoutSignal(t *testing.T) {
 	t.Parallel()
 
 	checkID := uuid.MustParse("00000000-0000-4000-8000-000000000022")
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	server := httptest.NewTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
-	t.Cleanup(server.Close)
+	client := server.Client()
 
-	cmd := rootCommandWithClientFactory(routeHealthchecksTo(t, server.URL))
+	cmd := rootCommandWithClientFactory(routeHealthchecksTo(t, server.URL, client.Transport))
 	cmd.SetArgs([]string{checkID.String()})
 	cmd.SetOut(&bytes.Buffer{})
 	var stderr bytes.Buffer
@@ -135,6 +134,77 @@ func TestRootCommandOmitsCheckIDWithoutSignal(t *testing.T) {
 	}
 	if strings.Contains(stderr.String(), checkID.String()) {
 		t.Fatalf("stderr exposed check ID: %q", stderr.String())
+	}
+}
+
+func TestRootCommandAcceptsStandardUUIDForms(t *testing.T) {
+	t.Parallel()
+
+	const canonical = "00000000-0000-4000-8000-000000000023"
+	tests := []struct {
+		name    string
+		checkID string
+	}{
+		{name: "canonical", checkID: canonical},
+		{name: "braced", checkID: "{" + canonical + "}"},
+		{name: "URN", checkID: "urn:uuid:" + canonical},
+		{name: "raw hexadecimal", checkID: "00000000000040008000000000000023"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			requestPath := make(chan string, 1)
+			cmd := rootCommandWithClientFactory(func(hc.RetryConfig) (*http.Client, error) {
+				return &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+					requestPath <- req.URL.Path
+					return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Request: req}, nil
+				})}, nil
+			})
+			cmd.SetArgs([]string{tc.checkID})
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+			if got, want := <-requestPath, "/"+canonical; got != want {
+				t.Fatalf("request path = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestRootCommandRejectsNonstandardUUIDForms(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		checkID string
+	}{
+		{name: "uppercase URN prefix", checkID: "URN:UUID:00000000-0000-4000-8000-000000000023"},
+		{name: "wrapped without braces", checkID: "x00000000-0000-4000-8000-000000000023y"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			factoryCalled := false
+			cmd := rootCommandWithClientFactory(func(hc.RetryConfig) (*http.Client, error) {
+				factoryCalled = true
+				return http.DefaultClient, nil
+			})
+			cmd.SetArgs([]string{tc.checkID})
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+
+			if err := cmd.Execute(); err == nil {
+				t.Fatal("Execute() error = nil, want invalid check ID error")
+			}
+			if factoryCalled {
+				t.Fatal("client factory called for invalid check ID")
+			}
+		})
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,8 @@
 module github.com/sosheskaz/healthchecksio-cli
 
-go 1.25.4
+go 1.27.0
 
 require (
-	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/spf13/cobra v1.10.2
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,6 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
-github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
-github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-hclog v1.6.3 h1:Qr2kF+eVWjTiYmU7Y31tYlP1h0q/X3Nl3tPGdaB11/k=

--- a/internal/hc/client_test.go
+++ b/internal/hc/client_test.go
@@ -11,9 +11,10 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
+	"uuid"
 
-	"github.com/google/uuid"
 	"github.com/hashicorp/go-retryablehttp"
 )
 
@@ -199,19 +200,17 @@ func TestRetryingHTTPClientRetriesExpectedStatuses(t *testing.T) {
 			t.Parallel()
 
 			var requests atomic.Int32
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			server := httptest.NewTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				requests.Add(1)
 				if tc.status == http.StatusTooManyRequests {
 					w.Header().Set("Retry-After", "0")
 				}
 				w.WriteHeader(tc.status)
 			}))
-			t.Cleanup(server.Close)
 
-			check := newRetryTestCheck(t, server.URL, tc.attempts)
+			check := newRetryTestCheck(t, server, tc.attempts)
 			err := check.Success(t.Context())
-			var statusErr BadStatusError
-			if !errors.As(err, &statusErr) {
+			if _, ok := errors.AsType[BadStatusError](err); !ok {
 				t.Fatalf("Success() error = %T %[1]v, want BadStatusError", err)
 			}
 			if got := requests.Load(); got != tc.wantRequests {
@@ -228,7 +227,7 @@ func TestRetryingHTTPClientReplaysRequestBody(t *testing.T) {
 		mu     sync.Mutex
 		bodies []string
 	)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Errorf("io.ReadAll() error = %v", err)
@@ -243,9 +242,8 @@ func TestRetryingHTTPClientReplaysRequestBody(t *testing.T) {
 		}
 		w.WriteHeader(http.StatusOK)
 	}))
-	t.Cleanup(server.Close)
 
-	check := newRetryTestCheck(t, server.URL, 2)
+	check := newRetryTestCheck(t, server, 2)
 	if err := check.Log(t.Context(), "diagnostics"); err != nil {
 		t.Fatalf("Log() error = %v", err)
 	}
@@ -285,7 +283,7 @@ func TestRetryingHTTPClientRetriesConnectionFailure(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	check := newRetryTestCheck(t, server.URL, 2)
+	check := newRetryTestCheckForURL(t, server.URL, 2)
 	if err := check.Success(t.Context()); err != nil {
 		t.Fatalf("Success() error = %v", err)
 	}
@@ -347,35 +345,47 @@ func TestRetryingHTTPClientAppliesTLSHandshakeTimeout(t *testing.T) {
 func TestRetryingHTTPClientRetriesUntilContextDeadline(t *testing.T) {
 	t.Parallel()
 
-	var requests atomic.Int32
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		requests.Add(1)
-		w.WriteHeader(http.StatusServiceUnavailable)
-	}))
-	t.Cleanup(server.Close)
+	synctest.Test(t, func(t *testing.T) {
+		var requests atomic.Int32
+		server := httptest.NewTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			requests.Add(1)
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}))
 
-	check := newRetryTestCheckWithBackoff(t, server.URL, 0, 20*time.Millisecond)
-	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Millisecond)
-	defer cancel()
-	started := time.Now()
-	err := check.Success(ctx)
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("Success() error = %T %[1]v, want context deadline exceeded", err)
-	}
-	if got := requests.Load(); got < 2 {
-		t.Fatalf("requests = %d, want at least 2", got)
-	}
-	if elapsed := time.Since(started); elapsed > 500*time.Millisecond {
-		t.Fatalf("Success() elapsed = %s, want prompt cancellation", elapsed)
-	}
+		check := newRetryTestCheckWithBackoff(t, server, 0, 20*time.Millisecond)
+		ctx, cancel := context.WithTimeout(t.Context(), 60*time.Millisecond)
+		defer cancel()
+		started := time.Now()
+		err := check.Success(ctx)
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("Success() error = %T %[1]v, want context deadline exceeded", err)
+		}
+		if got := requests.Load(); got < 2 {
+			t.Fatalf("requests = %d, want at least 2", got)
+		}
+		if elapsed := time.Since(started); elapsed != 60*time.Millisecond {
+			t.Fatalf("Success() elapsed = %s, want 60ms", elapsed)
+		}
+	})
 }
 
-func newRetryTestCheck(t *testing.T, serverURL string, attempts int) *Check {
+func newRetryTestCheck(t *testing.T, server *httptest.Server, attempts int) *Check {
 	t.Helper()
-	return newRetryTestCheckWithBackoff(t, serverURL, attempts, time.Nanosecond)
+	return newRetryTestCheckWithBackoff(t, server, attempts, time.Nanosecond)
 }
 
-func newRetryTestCheckWithBackoff(t *testing.T, serverURL string, attempts int, maxBackoff time.Duration) *Check {
+func newRetryTestCheckWithBackoff(t *testing.T, server *httptest.Server, attempts int, maxBackoff time.Duration) *Check {
+	t.Helper()
+	client := server.Client()
+	return newRetryTestCheckWithTransport(t, server.URL, client.Transport, attempts, maxBackoff)
+}
+
+func newRetryTestCheckForURL(t *testing.T, serverURL string, attempts int) *Check {
+	t.Helper()
+	return newRetryTestCheckWithTransport(t, serverURL, nil, attempts, time.Nanosecond)
+}
+
+func newRetryTestCheckWithTransport(t *testing.T, serverURL string, transport http.RoundTripper, attempts int, maxBackoff time.Duration) *Check {
 	t.Helper()
 
 	client, err := NewRetryingHTTPClient(RetryConfig{
@@ -385,6 +395,13 @@ func newRetryTestCheckWithBackoff(t *testing.T, serverURL string, attempts int, 
 	})
 	if err != nil {
 		t.Fatalf("NewRetryingHTTPClient() error = %v", err)
+	}
+	if transport != nil {
+		retryTransport, ok := client.Transport.(*retryablehttp.RoundTripper)
+		if !ok {
+			t.Fatalf("client.Transport = %T, want *retryablehttp.RoundTripper", client.Transport)
+		}
+		retryTransport.Client.HTTPClient.Transport = transport
 	}
 	check, err := NewUUIDCheck(
 		uuid.MustParse("00000000-0000-4000-8000-000000000008"),

--- a/internal/hc/healthcheck.go
+++ b/internal/hc/healthcheck.go
@@ -7,8 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-
-	"github.com/google/uuid"
+	"uuid"
 )
 
 const (
@@ -46,7 +45,7 @@ type Check struct {
 
 // NewUUIDCheck creates a new health check for the given UUID.
 func NewUUIDCheck(id uuid.UUID, opts ...CheckOption) (*Check, error) {
-	if id == uuid.Nil {
+	if id == uuid.Nil() {
 		return nil, BadConfigError{Message: "id must not be nil"}
 	}
 	options := &checkOptions{}

--- a/internal/hc/request.go
+++ b/internal/hc/request.go
@@ -7,8 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-
-	"github.com/google/uuid"
+	"uuid"
 )
 
 type requestOptions struct {

--- a/internal/hc/request_test.go
+++ b/internal/hc/request_test.go
@@ -8,20 +8,31 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
-
-	"github.com/google/uuid"
+	"uuid"
 )
+
+func TestNewUUIDCheckRejectsNilUUID(t *testing.T) {
+	t.Parallel()
+
+	check, err := NewUUIDCheck(uuid.Nil())
+	if err == nil {
+		t.Fatal("NewUUIDCheck() error = nil, want nil UUID error")
+	}
+	if check != nil {
+		t.Fatalf("NewUUIDCheck() check = %v, want nil", check)
+	}
+}
 
 func TestCheckReportsBadHTTPStatus(t *testing.T) {
 	t.Parallel()
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	server := httptest.NewTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
-	t.Cleanup(server.Close)
+	client := server.Client()
 
 	checkID := uuid.MustParse("00000000-0000-4000-8000-000000000001")
-	check, err := NewUUIDCheck(checkID, WithBaseURL(server.URL))
+	check, err := NewUUIDCheck(checkID, WithBaseURL(server.URL), WithHTTPClient(client))
 	if err != nil {
 		t.Fatalf("NewUUIDCheck() error = %v", err)
 	}
@@ -66,15 +77,15 @@ func TestCheckAddsRunIDToExistingQuery(t *testing.T) {
 	t.Parallel()
 
 	requestQuery := make(chan url.Values, 1)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestQuery <- r.URL.Query()
 		w.WriteHeader(http.StatusOK)
 	}))
-	t.Cleanup(server.Close)
+	client := server.Client()
 
 	checkID := uuid.MustParse("00000000-0000-4000-8000-000000000003")
 	runID := uuid.MustParse("00000000-0000-4000-8000-000000000004")
-	check, err := NewUUIDCheck(checkID, WithBaseURL(server.URL+"?existing=true"))
+	check, err := NewUUIDCheck(checkID, WithBaseURL(server.URL+"?existing=true"), WithHTTPClient(client))
 	if err != nil {
 		t.Fatalf("NewUUIDCheck() error = %v", err)
 	}
@@ -101,7 +112,7 @@ func TestCheckMethodsUseExpectedPathsAndBodies(t *testing.T) {
 	}
 
 	records := make(chan requestRecord, 5)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer func() { _ = r.Body.Close() }()
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
@@ -112,10 +123,10 @@ func TestCheckMethodsUseExpectedPathsAndBodies(t *testing.T) {
 		records <- requestRecord{path: r.URL.Path, body: string(body)}
 		w.WriteHeader(http.StatusOK)
 	}))
-	t.Cleanup(server.Close)
+	client := server.Client()
 
 	checkID := uuid.MustParse("00000000-0000-4000-8000-000000000005")
-	check, err := NewUUIDCheck(checkID, WithBaseURL(server.URL))
+	check, err := NewUUIDCheck(checkID, WithBaseURL(server.URL), WithHTTPClient(client))
 	if err != nil {
 		t.Fatalf("NewUUIDCheck() error = %v", err)
 	}


### PR DESCRIPTION
Adopt Go 1.27 across the codebase and repair Ko package resolution for releases built with the new toolchain.

## Why

The v1.4.3 release built the platform binaries but failed in the Ko phase because Go 1.27 rejects the empty package path previously inferred by the release configuration.

## Changes

- Raise the module baseline to Go 1.27 and replace `github.com/google/uuid` with the new standard-library `uuid` package.
- Use Go 1.27's in-memory HTTP test servers and synthetic-time helpers, with explicit UUID compatibility coverage.
- Configure Ko with `main: .` and local-only snapshot image loading.
- Document the Go and macOS version requirements.

## Caveats

The local Docker daemon was unavailable, so Ko snapshot validation relied on CI. The repository's Ko-enabled snapshot workflow completed successfully.

## Breaking changes

Building from source now requires Go 1.27. macOS binaries built with this toolchain require macOS 13 Ventura or later.
